### PR TITLE
Add bash and curl to the packages installed on the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 ADD package.json package-lock.json pyproject.toml poetry.lock Makefile /app/
 
-RUN apk add build-base libffi-dev npm
+RUN apk add build-base libffi-dev npm bash curl
 
 RUN pip install poetry
 RUN make install


### PR DESCRIPTION
This means we can provide a consistent shell & minimal set of tools across Mavis and the reporting image, removing the need for special-casing and local hacks for healthchecks, etc.
