### PR TITLE
Add ROOT_URL to config, to fix redirect issue on sandbox-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,6 @@ To do this, it requires:
 1. A copy of the main Mavis app must be running and available at the URL given in the `MAVIS_ROOT_URL` env var
 2. That copy of Mavis must:
    - include [this corresponding PR](https://github.com/nhsuk/manage-vaccinations-in-schools/pull/3866/)
-   - have the `reporting_app` feature flag enabled
-   - have a value for `Settings.mavis_reporting_app.client_id` (..which can also be set via the `MAVIS_REPORTING_APP__CLIENT_ID` environment variable) which matches this application's `CLIENT_ID` value
-   - have a value for `Settings.mavis_reporting_app.client_secret` (..which can also be set via the `MAVIS_REPORTING_APP__CLIENT_SECRET` environment variable) which matches this application's `CLIENT_SECRET` value
+   - have the `reporting_api` feature flag enabled
+   - have a value for `Settings.mavis_reporting_api.client_app.client_id` (..which can also be set via the `MAVIS_REPORTING_API__CLIENT_ID` environment variable) which matches this application's `CLIENT_ID` value
+   - have a value for `Settings.mavis_reporting_api.client_app.client_secret` (..which can also be set via the `MAVIS_REPORTING_API__CLIENT_SECRET` environment variable) which matches this application's `CLIENT_SECRET` value

--- a/config/container_variables.yml
+++ b/config/container_variables.yml
@@ -14,6 +14,7 @@ environments:
   training:
 
   sandbox-alpha:
-    MAVIS_ROOT_URL: http://sandbox-alpha.mavistesting.com/
+    ROOT_URL: https://sandbox-alpha.mavistesting.com/reporting/
+    MAVIS_ROOT_URL: https://sandbox-alpha.mavistesting.com/
     
   sandbox-beta:

--- a/mavis_reporting/config/__init__.py
+++ b/mavis_reporting/config/__init__.py
@@ -30,6 +30,8 @@ class Config:
     # (the default user from db/seeds.rb on the main mavis app)
     FAKE_LOGIN_ENABLED = str2bool(os.environ.get("FAKE_LOGIN_ENABLED"))
 
+    ROOT_URL = os.environ.get("ROOT_URL")
+
 
 class DevelopmentConfig(Config):
     """Development configuration"""

--- a/mavis_reporting/helpers/auth_helper.py
+++ b/mavis_reporting/helpers/auth_helper.py
@@ -88,8 +88,8 @@ def minimal_jwt(data):
         "data": {
             "user": {
                 "id": data["user"]["id"],
-                "reporting_app_session_token": data["user"][
-                    "reporting_app_session_token"
+                "reporting_api_session_token": data["user"][
+                    "reporting_api_session_token"
                 ],
             },
             "cis2_info": data["cis2_info"],
@@ -117,7 +117,7 @@ def fake_user_session_info():
             "given_name": "Nurse",
             "family_name": "Joy",
             "session_token": None,
-            "reporting_app_session_token": None,
+            "reporting_api_session_token": None,
             "fallback_role": "nurse",
         },
         "cis2_info": {

--- a/mavis_reporting/views.py
+++ b/mavis_reporting/views.py
@@ -43,7 +43,10 @@ def api_call():
     try:
         response = mavis_helper.api_call(current_app, session, "/api/reporting/totals")
     except Unauthorized:
-        return mavis_helper.login_and_return_after(current_app, request.url)
+        return_url = urllib.parse.urljoin(
+            current_app.config["ROOT_URL"] or request.server, request.full_path
+        )
+        return mavis_helper.login_and_return_after(current_app, return_url)
 
     data = response.json()
     return render_template("api_call.jinja", response=response, data=data)

--- a/tests/helpers/test_auth_helper.py
+++ b/tests/helpers/test_auth_helper.py
@@ -41,7 +41,7 @@ def mock_user_info():
         },
     }
     info["user"]["session_token"] = random_token()
-    info["user"]["reporting_app_session_token"] = random_token()
+    info["user"]["reporting_api_session_token"] = random_token()
     return info
 
 
@@ -87,7 +87,7 @@ def test_that_log_user_in_sets_minimal_jwt(
 
         assert jwt_payload["data"]["user"]["id"] == fake_data["user"]["id"]
         assert (
-            jwt_payload["data"]["user"]["reporting_app_session_token"]
-            == fake_data["user"]["reporting_app_session_token"]
+            jwt_payload["data"]["user"]["reporting_api_session_token"]
+            == fake_data["user"]["reporting_api_session_token"]
         )
         assert jwt_payload["data"]["cis2_info"] == fake_data["cis2_info"]


### PR DESCRIPTION
Update reporting_app_.. -> reporting_api_... in the docs, and add `ROOT_URL` config setting. 

This is to allow us to redirect correctly on a deployed environment, where the SSL terminates at the load balancer, so the container only sees an http:// request, and therefore it passes an incorrect redirect_uri back to the main Mavis app
