### PR TITLE
Fix redirect_uri losing the https on deployed hosts

### DIFF
--- a/mavis_reporting/helpers/url_helper.py
+++ b/mavis_reporting/helpers/url_helper.py
@@ -1,4 +1,4 @@
-from urllib.parse import urlparse, parse_qs, parse_qsl, urlencode, urlunparse
+from urllib.parse import urlparse, parse_qs, parse_qsl, urlencode, urlunparse, urljoin
 
 
 def url_without_param(url, param):
@@ -14,3 +14,9 @@ def url_without_param(url, param):
         return urlunparse(parsed_url)
     else:
         return url
+
+
+def externalise_current_url(current_app, request):
+    return urljoin(
+        current_app.config["ROOT_URL"] or request.host_url, request.full_path
+    )

--- a/tests/helpers/test_url_helper.py
+++ b/tests/helpers/test_url_helper.py
@@ -37,3 +37,33 @@ def test_url_without_param_with_a_single_param_that_is_not_present_makes_no_chan
         )
         == "https://some.domain/path/file.name?q=search+string&b=bbb&a=aaa&"
     )
+
+
+class MockRequest:
+    def __init__(self, **kwargs):
+        self.host_url = kwargs.get("host_url", None)
+        self.full_path = kwargs.get("full_path", None)
+
+
+def test_that_externalise_current_url_uses_root_url_if_given(app):
+    request = MockRequest(
+        host_url="http://my.server/", full_path="/reporting/full/path?query=val1"
+    )
+    with app.app_context():
+        app.config["ROOT_URL"] = "https://i.am.mavis:4000/reporting"
+        assert (
+            url_helper.externalise_current_url(app, request)
+            == "https://i.am.mavis:4000/reporting/full/path?query=val1"
+        )
+
+
+def test_that_externalise_current_url_uses_request_host_url_if_root_url_not_given(app):
+    request = MockRequest(
+        host_url="http://my.server/", full_path="/reporting/full/path?query=val1"
+    )
+    with app.app_context():
+        app.config["ROOT_URL"] = None
+        assert (
+            url_helper.externalise_current_url(app, request)
+            == "http://my.server/reporting/full/path?query=val1"
+        )


### PR DESCRIPTION
On deployed environments like `sandbox-alpha`, the SSL connection from outside terminates at the load balancer, and then it's just http for the internal traffic from the load balancer to the actual container. 

This means in those environments, we can't just use `request.url` as the `redirect_uri`, because it will come through as just http, not https.

When that happens, the resulting request gets redirected by the load balancer to the https version, but _that_ means that [Pythons' `requests` library then changes the `POST` into a `GET`](https://stackoverflow.com/questions/26149181/python-requests-post-doing-a-get), which means that Rails doesn't recognise the `/token/authorize` route which is POST-only.