### PR TITLE
Fix assets on deployed environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ FROM builder
 WORKDIR /app
 
 ADD ./mavis_reporting /app/mavis_reporting
+RUN make build-assets
 
 # Create a new group `app` with Group ID `1000`.
 RUN addgroup --gid 1000 app

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ sentinel: package.json package-lock.json pyproject.toml poetry.lock
 	
 	@touch sentinel
 
+build-assets: sentinel
+	@npm run build:scss 
+	@npm run build:js
+	
 .PHONY: install
 install: sentinel
 	

--- a/mavis_reporting/config/__init__.py
+++ b/mavis_reporting/config/__init__.py
@@ -21,7 +21,7 @@ class Config:
 
     # Flask config
     # Flask-internal secret
-    SECRET_KEY = os.environ.get("SECRET_KEY")
+    SECRET_KEY = os.environ.get("SECRET_KEY") or "placeholder-secret-key-replace-this"
     TEMPLATES_AUTO_RELOAD = True
     SESSION_TTL_SECONDS = int(os.environ.get("SESSION_TTL_SECONDS") or "600")
 

--- a/mavis_reporting/views.py
+++ b/mavis_reporting/views.py
@@ -12,8 +12,7 @@ from werkzeug.exceptions import Unauthorized
 
 import logging
 
-from mavis_reporting.helpers import mavis_helper
-from mavis_reporting.helpers import auth_helper
+from mavis_reporting.helpers import mavis_helper, auth_helper, url_helper
 
 logger = logging.getLogger(__name__)
 
@@ -43,9 +42,7 @@ def api_call():
     try:
         response = mavis_helper.api_call(current_app, session, "/api/reporting/totals")
     except Unauthorized:
-        return_url = urllib.parse.urljoin(
-            current_app.config["ROOT_URL"] or request.server, request.full_path
-        )
+        return_url = url_helper.externalise_current_url(current_app, request)
         return mavis_helper.login_and_return_after(current_app, return_url)
 
     data = response.json()

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build:scss": "sass mavis_reporting/assets/scss/app.scss:mavis_reporting/static/css/app.css --style=compressed --no-source-map",
+    "build:scss": "sass --load-path=node_modules mavis_reporting/assets/scss/app.scss:mavis_reporting/static/css/app.css --style=compressed --no-source-map",
     "build:scss:dev": "sass --load-path=node_modules --watch mavis_reporting/assets/scss:mavis_reporting/static/css --style=expanded --source-map",
     "build:js": "esbuild mavis_reporting/javascript/app.js --bundle --outfile=mavis_reporting/static/js/app.js --minify",
     "build:js:dev": "esbuild mavis_reporting/javascript/app.js --bundle --outfile=mavis_reporting/static/js/app.js --sourcemap --minify --watch"


### PR DESCRIPTION
Add an explicit build of assets in the Dockerfile, as static assets (stylesheets, etc) were not present when deployed
