### PR TITLE
Only show the debug session dump in development

### DIFF
--- a/mavis_reporting/config/__init__.py
+++ b/mavis_reporting/config/__init__.py
@@ -32,6 +32,8 @@ class Config:
 
     ROOT_URL = os.environ.get("ROOT_URL")
 
+    SHOW_SESSION_DUMP = str2bool(os.environ.get("SHOW_SESSION_DUMP"))
+
 
 class DevelopmentConfig(Config):
     """Development configuration"""
@@ -39,6 +41,7 @@ class DevelopmentConfig(Config):
     DEBUG = True
     TESTING = False
     LOG_LEVEL = "DEBUG"
+    SHOW_SESSION_DUMP = True
     # Uncomment this line to allow developing locally without having
     # the main Mavis running:
     # FAKE_LOGIN_ENABLED = True

--- a/mavis_reporting/templates/layouts/base.jinja
+++ b/mavis_reporting/templates/layouts/base.jinja
@@ -40,16 +40,18 @@
 {% endblock %}
 
 
-{% block session %}
-  <details>
-    <summary>session</summary>
-      <dl>
-      {% for key in session %}
-        <dt>{{ key }}</dt>
-          <dd>{{ session.get(key) }}</dd>
-      {% endfor %}
-      </dl>
-    </details>
-{% endblock %}
+{% if config["SHOW_SESSION_DUMP"] %}
+  {% block session %}
+    <details>
+      <summary>session</summary>
+        <dl>
+        {% for key in session %}
+          <dt>{{ key }}</dt>
+            <dd>{{ session.get(key) }}</dd>
+        {% endfor %}
+        </dl>
+      </details>
+  {% endblock %}
+{% endif %}
 
 {% endblock %}


### PR DESCRIPTION
It's useful for debugging, but probably shouldn't be shown anywhere except in local development