### PR TITLE
Set user_nav in session if it is present in the Mavis authorization response

### DIFF
--- a/mavis_reporting/helpers/mavis_helper.py
+++ b/mavis_reporting/helpers/mavis_helper.py
@@ -35,7 +35,8 @@ def verify_auth_code(code, current_app):
 
     auth_code_response_data = r.json()
     jwt_data = auth_helper.decode_jwt(auth_code_response_data["jwt"], current_app)
-    return jwt_data["data"]
+    user_nav = auth_code_response_data.get("user_nav", "")
+    return {"jwt_data": jwt_data["data"], "user_nav": user_nav}
 
 
 def api_call(current_app, session, path, params={}):

--- a/mavis_reporting/templates/layouts/base.jinja
+++ b/mavis_reporting/templates/layouts/base.jinja
@@ -10,7 +10,8 @@
 {% block header %}
 {{ header({
   "service": {
-    "name": "Manage vaccinations in schools"
+    "text": "Manage vaccinations in schools",
+    "href": url_for('main.index')
   },
   "navigation": {
     "items": [
@@ -27,7 +28,8 @@
         "text": "Test API call"
       }
     ]
-  }
+  },
+  "account": session.user_nav if session.user_nav else None
 }) }}
 {% endblock %}
 

--- a/scripts/populate_ssm_parameters.py
+++ b/scripts/populate_ssm_parameters.py
@@ -24,9 +24,8 @@ def load_yaml_config(file_path: str) -> Dict[str, Any]:
 def extract_cloud_variables(
     config: Dict[str, Any], environment: str, server_type: str
 ) -> List[str]:
-    """
-    Extract cloud variables from YAML config for the given environment and server type.
-    """
+    """Extract cloud variables from YAML config for the given
+    environment and server type."""
     cloud_vars = []
     env_config = config[environment]
     if not env_config:
@@ -97,10 +96,9 @@ Examples:
 
     ssm_parameter_path = f"/{args.environment}/envs/{args.server_type}"
     if cloud_vars.__len__() == 0:
-        print(
-            f"No cloud variables found for '{args.environment}' and "
-            f"'{args.server_type}', skipping update."
-        )
+        msg = f"No cloud variables found for '{args.environment}'"
+        msg += f" and '{args.server_type}', skipping update"
+        print(msg)
     else:
         update_ssm_parameter(ssm_parameter_path, cloud_vars, args.app_version)
         print("Cloud variables updated successfully")


### PR DESCRIPTION
This will allow us to render it out into the header, so that the user gets a more consistent and less disorientating header on the reporting app.

Depends on [Mavis PR #4478](https://github.com/nhsuk/manage-vaccinations-in-schools/pull/4478) which adds the `user_nav` key into the response

## After

<img width="2766" height="1152" alt="image" src="https://github.com/user-attachments/assets/c43f4b44-123c-4d74-bab3-fd996272088a" />
