### PR TITLE
Add design of download page for MVP

### DIFF
--- a/mavis_reporting/config/__init__.py
+++ b/mavis_reporting/config/__init__.py
@@ -32,8 +32,6 @@ class Config:
 
     ROOT_URL = os.environ.get("ROOT_URL")
 
-    SHOW_SESSION_DUMP = str2bool(os.environ.get("SHOW_SESSION_DUMP"))
-
 
 class DevelopmentConfig(Config):
     """Development configuration"""
@@ -41,7 +39,6 @@ class DevelopmentConfig(Config):
     DEBUG = True
     TESTING = False
     LOG_LEVEL = "DEBUG"
-    SHOW_SESSION_DUMP = True
     # Uncomment this line to allow developing locally without having
     # the main Mavis running:
     # FAKE_LOGIN_ENABLED = True
@@ -53,7 +50,6 @@ class ProductionConfig(Config):
     DEBUG = False
     TESTING = False
     LOG_LEVEL = "INFO"
-    SHOW_SESSION_DUMP = False
 
 
 class StagingConfig(Config):
@@ -62,7 +58,6 @@ class StagingConfig(Config):
     DEBUG = False
     TESTING = False
     LOG_LEVEL = "INFO"
-    SHOW_SESSION_DUMP = False
 
 
 class TestingConfig(Config):

--- a/mavis_reporting/templates/download.jinja
+++ b/mavis_reporting/templates/download.jinja
@@ -1,0 +1,95 @@
+{% from "components/heading.jinja" import heading %}
+{% from "select/macro.jinja" import select %}
+{% from "checkboxes/macro.jinja" import checkboxes %}
+{% from "button/macro.jinja" import button %}
+
+{% extends 'layouts/base.jinja' %}
+
+{% block pageTitle %}Download data{% endblock %}
+
+{% block page_content %}
+
+{{ heading({
+  "text": "Download data",
+  "level": 1,
+  "size": "xl",
+}) }}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-u-margin-bottom-3 nhsuk-grid-column-two-thirds">
+    <p>Download data for the number of vaccinations given to children in schools by month for your organisation.</p>
+  </div>
+</div>
+
+<form action="{{ url_for('main.download') }}" method="post">
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-u-margin-bottom-3 nhsuk-grid-column-two-thirds">
+    {{ heading({
+      "text": "Choose a programme",
+      "level": 2,
+      "size": "s",
+    }) }}
+
+    {% set programme_items = [] %}
+    {% for programme in programmes %}
+      {% set _ = programme_items.append({
+        "text": programme["name"],
+        "value": programme["code"],
+        "selected": programme["code"] == "hpv",
+      }) %}
+    {% endfor %}
+
+    {{ select({
+      "label": {
+        "text": "Programme",
+        "classes": "nhsuk-u-visually-hidden",
+      },
+      "id": "programme",
+      "name": "programme",
+      "items": programme_items,
+    }) }}
+  </div>
+</div>
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-u-margin-bottom-3 nhsuk-grid-column-two-thirds">
+    {{ heading({
+      "text": "Choose other variables",
+      "level": 2,
+      "size": "s",
+    }) }}
+
+    {{ checkboxes({
+      "id": "variables",
+      "name": "variables",
+      "items": [
+        {
+          "text": "Local authority",
+          "value": "local_authority",
+        },
+        {
+          "text": "School",
+          "value": "school",
+        },
+        {
+          "text": "Year group",
+          "value": "year_group",
+        },
+        {
+          "text": "Gender",
+          "value": "gender",
+        }
+      ],
+    }) }}
+  </div>
+</div>
+
+{{ button({
+  "text": "Download data",
+  "type": "submit",
+}) }}
+
+</form>
+
+{% endblock %}

--- a/mavis_reporting/templates/download.jinja
+++ b/mavis_reporting/templates/download.jinja
@@ -5,12 +5,12 @@
 
 {% extends 'layouts/base.jinja' %}
 
-{% block pageTitle %}Download data{% endblock %}
+{% block pageTitle %}Download reporting data – {{ site_title }}{% endblock %}
 
 {% block page_content %}
 
 {{ heading({
-  "text": "Download data",
+  "text": "Download reporting data",
   "level": 1,
   "size": "xl",
 }) }}

--- a/mavis_reporting/templates/layouts/base.jinja
+++ b/mavis_reporting/templates/layouts/base.jinja
@@ -15,16 +15,12 @@
   "showNav": "true",
   "primaryLinks": [
       {
-        "url": config["MAVIS_ROOT_URL"],
-        "label": "Home",
-      },
-      {
-        "url": config["MAVIS_ROOT_URL"] + 'dashboard',
+        "url": url_for('main.index'),
         "label": "Dashboard",
       },
       {
-        "url": "/reporting/",
-        "label": "Reporting",
+        "url": url_for('main.download'),
+        "label": "Download data",
       },
       {
         "url": "/reporting/api-call/",

--- a/mavis_reporting/templates/layouts/base.jinja
+++ b/mavis_reporting/templates/layouts/base.jinja
@@ -35,19 +35,4 @@
 {% block page_content %}
 {% endblock %}
 
-
-{% if config["SHOW_SESSION_DUMP"] %}
-  {% block session %}
-    <details>
-      <summary>session</summary>
-        <dl>
-        {% for key in session %}
-          <dt>{{ key }}</dt>
-            <dd>{{ session.get(key) }}</dd>
-        {% endfor %}
-        </dl>
-      </details>
-  {% endblock %}
-{% endif %}
-
 {% endblock %}

--- a/mavis_reporting/views.py
+++ b/mavis_reporting/views.py
@@ -21,6 +21,14 @@ logger = logging.getLogger(__name__)
 main = Blueprint("main", __name__)
 
 
+@main.context_processor
+def inject_mavis_data():
+    """Inject common data into the template context."""
+    return {
+        "site_title": "Manage vaccinations in schools",
+    }
+
+
 @main.route("/")
 @auth_helper.login_required
 def index():

--- a/mavis_reporting/views.py
+++ b/mavis_reporting/views.py
@@ -4,6 +4,8 @@ from flask import (
     request,
     session,
     current_app,
+    redirect,
+    url_for,
 )
 
 from healthcheck import HealthCheck
@@ -23,6 +25,21 @@ main = Blueprint("main", __name__)
 @auth_helper.login_required
 def index():
     return render_template("default.jinja")
+
+
+@main.route("/download", methods=["GET", "POST"])
+@auth_helper.login_required
+def download():
+    if request.method == "POST":
+        return redirect(url_for("main.download"))
+
+    programmes = [
+        {"code": "hpv", "name": "HPV"},
+        {"code": "flu", "name": "Flu"},
+        {"code": "menacwy", "name": "MenACWY"},
+        {"code": "td-ipv", "name": "Td/IPV"},
+    ]
+    return render_template("download.jinja", programmes=programmes)
 
 
 @main.errorhandler(404)


### PR DESCRIPTION
This PR adds a static page for the design of the first version of the functionality to download data.

Initially this is scoped to just support download of monthly figures of vaccinations delivered by a single SAIS provider.

In future, this functionality will need to expand, and the design change accordingly, to allow for download of other measures and for regional commissioner users to select a specific provider to download data for. At this point, the page may need to be broken over multiple pages as a wizard.

<img width="1214" height="1032" alt="Screenshot 2025-09-03 at 17 14 47" src="https://github.com/user-attachments/assets/5dfdde57-f51a-4ed3-be21-98b1da4642f3" />

It also removes the session dump functionality as this was only temporarily needed for debugging the auth implementation.