### PR TITLE
Add awscli to tools

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,5 @@
 [tools]
+awscli = "2.27.46"
 gitleaks = "latest"
 python = "3.13"
 uv = "latest"


### PR DESCRIPTION
This can be used to tail logs or debug live issues with the reporting app.