### PR TITLE
Change package-ecosystem to uv for dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,27 +1,22 @@
 version: 2
 
 updates:
-
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
-
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "daily"
-
   - package-ecosystem: "terraform"
     directory: "/"
     schedule:


### PR DESCRIPTION
This ensures it correctly updates the uv.lock when bumping deps.