### PR TITLE
Remove reference to manifest.json

### DIFF
--- a/mavis/reporting/templates/layouts/base.jinja
+++ b/mavis/reporting/templates/layouts/base.jinja
@@ -2,6 +2,13 @@
 {% from 'header/macro.jinja' import header %}
 {% extends 'nhsuk/template.jinja' %}
 
+{% block headIcons %}
+<link rel="icon" href="{{ static('favicons/favicon.ico') }}" sizes="48x48">
+<link rel="icon" href="{{ static('favicons/favicon.svg') }}" sizes="any" type="image/svg+xml">
+<link rel="mask-icon" href="{{ static('favicons/nhsuk-icon-mask.svg') }}" color="#005eb8">
+<link rel="apple-touch-icon" href="{{ static('favicons/nhsuk-icon-180.png') }}">
+{% endblock %}
+
 {% block head %}
 <link rel="stylesheet" href="{{ static('css/app.css') }}">
 <script type="module" src="{{ static('js/app.js') }}"></script>


### PR DESCRIPTION
The default template requests a manifest that ends up mapping to a 404 on Mavis, which we assume is what's causing a bug where the Reporting app pulls in the CSS and JS from Mavis into the frontend.

This also correctly maps the favicons to the ones in the reporting app, which are the same, but nonetheless it was weird to link to the Mavis ones.