### PR TITLE
Fix JS build

### DIFF
--- a/mavis/reporting/javascript/app.js
+++ b/mavis/reporting/javascript/app.js
@@ -1,2 +1,3 @@
-import initHeader from "nhsuk-frontend/packages/components/header/header.js";
-initHeader();
+import { createAll, Header } from "nhsuk-frontend";
+
+createAll(Header);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build:scss": "sass --load-path=node_modules mavis/reporting/assets/scss/app.scss:mavis/reporting/static/css/app.css --style=compressed --no-source-map",
     "build:scss:dev": "sass --load-path=node_modules --watch mavis/reporting/assets/scss:mavis/reporting/static/css --style=expanded --source-map",
     "build:js": "esbuild mavis/reporting/javascript/app.js --bundle --outfile=mavis/reporting/static/js/app.js --minify",
-    "build:js:dev": "esbuild mavis/reporting/javascript/app.js --bundle --outfile=mavis/reporting/static/js/app.js --sourcemap --minify --watch"
+    "build:js:dev": "esbuild mavis/reporting/javascript/app.js --bundle --outfile=mavis/reporting/static/js/app.js --sourcemap --minify --watch=forever"
   },
   "dependencies": {
     "nhsuk-frontend": "^10.0.0"


### PR DESCRIPTION
Turns out the JS build wasn't working via `mise dev` as stdin to esbuild was being closed before it was done generating the output, causing the process to terminate. This PR changes to use `esbuild`'s `--watch=forever` to force esbuild to keep running and makes sure the output bundle is created.

The PR also changes the way the NHS.UK frontend header component is imported and initialised to fix the console error we were seeing.

