### PR TITLE
Distinguish between self-declared and reported vaccinated elsewhere

### DIFF
--- a/mavis/reporting/api_client/client.py
+++ b/mavis/reporting/api_client/client.py
@@ -4,7 +4,12 @@ class MavisApiClient:
         data["vaccinated_percentage"] = data["vaccinated"] / n
         data["not_vaccinated_percentage"] = data["not_vaccinated"] / n
         data["vaccinated_by_sais_percentage"] = data["vaccinated_by_sais"] / n
-        data["vaccinated_elsewhere_percentage"] = data["vaccinated_elsewhere"] / n
+        data["vaccinated_elsewhere_declared_percentage"] = (
+            data["vaccinated_elsewhere_declared"] / n
+        )
+        data["vaccinated_elsewhere_reported_percentage"] = (
+            data["vaccinated_elsewhere_reported"] / n
+        )
         data["vaccinated_previously_percentage"] = data["vaccinated_previously"] / n
         return data
 
@@ -14,7 +19,8 @@ class MavisApiClient:
             "vaccinated": 456,
             "not_vaccinated": 90,
             "vaccinated_by_sais": 400,
-            "vaccinated_elsewhere": 56,
+            "vaccinated_elsewhere_declared": 32,
+            "vaccinated_elsewhere_reported": 24,
             "vaccinated_previously": 0,
             "vaccinations_given": 402,
             "monthly_vaccinations_given": [

--- a/mavis/reporting/assets/scss/_data_table.scss
+++ b/mavis/reporting/assets/scss/_data_table.scss
@@ -1,16 +1,26 @@
 @use "config" as *;
 
-.nhsuk-table--data {
-  th,
-  td {
-    padding: 12px;
+.nhsuk-table {
+  &--data {
+
+    th,
+    td {
+      padding: 12px;
+    }
+
+    .nhsuk-table__section-start {
+      border-left: 1px solid $color_nhsuk-grey-4;
+    }
+
+    .nhsuk-table__cell--bold {
+      font-weight: 700;
+    }
   }
 
-  .nhsuk-table__section-start {
-    border-left: 1px solid $color_nhsuk-grey-4;
-  }
-
-  .nhsuk-table__cell--bold {
-    font-weight: 700;
+  &--with-total {
+    .nhsuk-table__row:last-child {
+      background-color: $color_nhsuk-grey-5;
+      font-weight: 600;
+    }
   }
 }

--- a/mavis/reporting/templates/vaccinations.jinja
+++ b/mavis/reporting/templates/vaccinations.jinja
@@ -66,10 +66,20 @@
       <div class="nhsuk-grid-column-one-quarter nhsuk-card-group__item app-card-group__item">
         {{ card({
           "classes": "app-card",
-          "heading": "Vaccinated elsewhere",
+          "heading": "Vaccinated elsewhere (self-declared)",
           "headingClasses": "nhsuk-heading-xs",
           "headingLevel": 3,
-          "descriptionHtml": "<p class='nhsuk-card__description'>" ~ data["vaccinated_elsewhere_percentage"] | percentage ~ "<span class='nhsuk-card__caption'>" ~ data["vaccinated_elsewhere"] | thousands ~ " children</span></p>",
+          "descriptionHtml": "<p class='nhsuk-card__description'>" ~ data["vaccinated_elsewhere_declared_percentage"] | percentage ~ "<span class='nhsuk-card__caption'>" ~ data["vaccinated_elsewhere_declared"] | thousands ~ " children</span></p>",
+        }) }}
+      </div>
+
+      <div class="nhsuk-grid-column-one-quarter nhsuk-card-group__item app-card-group__item">
+        {{ card({
+          "classes": "app-card",
+          "heading": "Vaccinated elsewhere (reported)",
+          "headingClasses": "nhsuk-heading-xs",
+          "headingLevel": 3,
+          "descriptionHtml": "<p class='nhsuk-card__description'>" ~ data["vaccinated_elsewhere_reported_percentage"] | percentage ~ "<span class='nhsuk-card__caption'>" ~ data["vaccinated_elsewhere_reported"] | thousands ~ " children</span></p>",
         }) }}
       </div>
 
@@ -82,16 +92,6 @@
           "descriptionHtml": "<p class='nhsuk-card__description'>" ~ data["vaccinated_previously_percentage"] | percentage ~ "<span class='nhsuk-card__caption'>" ~ data["vaccinated_previously"] | thousands ~ " children</span></p>",
         }) }}
       </div>
-
-      <div class="nhsuk-grid-column-one-quarter nhsuk-card-group__item app-card-group__item">
-        {{ card({
-          "classes": "app-card",
-          "heading": "Vaccinations given",
-          "headingClasses": "nhsuk-heading-xs",
-          "headingLevel": 3,
-          "descriptionHtml": "<p class='nhsuk-card__description'>" ~ data["vaccinations_given"] | thousands ~ "<span class='nhsuk-card__caption'>given</span></p>",
-        }) }}
-      </div>
     </div>
 
     {% set rows = [] %}
@@ -101,10 +101,14 @@
         { "text": row.vaccinations_given | thousands, "format": "numeric" }
       ]) %}
     {% endfor %}
+    {% set _ = rows.append([
+      { "text": "Total" },
+      { "text": data.vaccinations_given | thousands, "format": "numeric" }
+    ]) %}
 
     {{ table({
       "heading": "Monthly vaccinations",
-      "tableClasses": "nhsuk-table--data",
+      "tableClasses": "nhsuk-table--data nhsuk-table--with-total",
       "panel": true,
       "head": [
         { "text": "Month", "format": "date"},


### PR DESCRIPTION
We need to draw a distinction between children we think were vaccinated elsewhere in this programme year based on two things:

- **Self-reported vaccinations:** via the parent refusing consent due to the child already being vaccinated or the child refusing the vaccination due to being already vaccinated
- **Recorded vaccinations:** via a vaccination record upload or via the Imms FHIR API integration

This PR splits these things out visually at least and moves the total number of vaccinations given into a total row at the bottom of the monthly vaccinations table.

Then all the headline stats count to children and the table counts vaccinations.

<img width="3492" height="5100" alt="Screen Shot 2025-09-23 at 18 15 16" src="https://github.com/user-attachments/assets/598fe6f9-c13d-481b-8f53-5fcd7f15fda5" />
