### PR TITLE
Download form redesign

### DIFF
--- a/mavis/reporting/api_client/client.py
+++ b/mavis/reporting/api_client/client.py
@@ -37,6 +37,14 @@ class MavisApiClient:
         data = response.json()
         return self.add_percentages(data)
 
+    def get_variables(self) -> list[dict]:
+        return [
+            {"value": "local_authority", "text": "Local Authority"},
+            {"value": "school", "text": "School"},
+            {"value": "year_group", "text": "Year group"},
+            {"value": "gender", "text": "Gender"},
+        ]
+
     def get_programmes(self) -> list[dict]:
         return [
             {"value": "flu", "text": "Flu"},

--- a/mavis/reporting/forms/data_type_form.py
+++ b/mavis/reporting/forms/data_type_form.py
@@ -1,0 +1,25 @@
+from flask_wtf import FlaskForm
+from wtforms import RadioField
+from wtforms.validators import InputRequired, ValidationError
+
+
+class DataTypeForm(FlaskForm):
+    """Form for selecting the type of data to download"""
+
+    CHILD_RECORDS = "child-records"
+    AGGREGATE_DATA = "aggregate-data"
+
+    data_type = RadioField(
+        id="data-type",
+        label="What kind of data do you want to download?",
+        name="data-type",
+        validators=[InputRequired(message="Please select a data type")],
+        choices=[
+            (CHILD_RECORDS, "Child-level vaccination record data"),
+            (AGGREGATE_DATA, "Aggregate vaccination and consent data"),
+        ],
+    )
+
+    def validate_data_type(self, field):
+        if not field.data:
+            raise ValidationError("Please select a data type")

--- a/mavis/reporting/forms/data_type_form.py
+++ b/mavis/reporting/forms/data_type_form.py
@@ -1,6 +1,6 @@
 from flask_wtf import FlaskForm
 from wtforms import RadioField
-from wtforms.validators import InputRequired, ValidationError
+from wtforms.validators import InputRequired
 
 
 class DataTypeForm(FlaskForm):
@@ -19,7 +19,3 @@ class DataTypeForm(FlaskForm):
             (AGGREGATE_DATA, "Aggregate vaccination and consent data"),
         ],
     )
-
-    def validate_data_type(self, field):
-        if not field.data:
-            raise ValidationError("Please select a data type")

--- a/mavis/reporting/forms/data_type_form.py
+++ b/mavis/reporting/forms/data_type_form.py
@@ -10,9 +10,9 @@ class DataTypeForm(FlaskForm):
     AGGREGATE_DATA = "aggregate-data"
 
     data_type = RadioField(
-        id="data-type",
+        id="data_type",
         label="What kind of data do you want to download?",
-        name="data-type",
+        name="data_type",
         validators=[InputRequired(message="Please select a data type")],
         choices=[
             (CHILD_RECORDS, "Child-level vaccination record data"),

--- a/mavis/reporting/forms/download_form.py
+++ b/mavis/reporting/forms/download_form.py
@@ -1,0 +1,31 @@
+from flask_wtf import FlaskForm
+from wtforms import RadioField, SelectMultipleField
+from wtforms.validators import InputRequired, Optional
+
+
+class DownloadForm(FlaskForm):
+    """Form for selecting the programme and variables to download data for"""
+
+    programme = RadioField(
+        id="programme",
+        label="Which programme do you want to download data for?",
+        name="programme",
+        validators=[InputRequired(message="Please select a programme")],
+    )
+
+    variables = SelectMultipleField(
+        name="variables",
+        id="variables",
+        label="How would you like to break down the data?",
+        validators=[Optional()],
+    )
+
+    def __init__(self, programmes, variables, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.programmes = programmes
+        self.programme.choices = [
+            (programme["value"], programme["text"]) for programme in self.programmes
+        ]
+        self.variables.choices = [
+            (variable["value"], variable["text"]) for variable in variables
+        ]

--- a/mavis/reporting/helpers/date_helper.py
+++ b/mavis/reporting/helpers/date_helper.py
@@ -18,3 +18,7 @@ def get_current_academic_year_range(date: datetime | None = None):
 
 def format_date_string(date: str):
     return datetime.strptime(date, "%Y-%m-%d").strftime("%d %B %Y")
+
+
+def get_last_updated_time():
+    return datetime.now().strftime("%d %B %Y at %H:00")

--- a/mavis/reporting/helpers/secondary_nav_helper.py
+++ b/mavis/reporting/helpers/secondary_nav_helper.py
@@ -10,7 +10,7 @@ def generate_secondary_nav_items(organisation_code: str, current_page: str):
         },
         {
             "text": "Download data",
-            "href": url_for("main.download", code=organisation_code),
+            "href": url_for("main.start_download", code=organisation_code),
             "current": current_page == "download",
         },
     ]

--- a/mavis/reporting/templates/components/form_error_summary.jinja
+++ b/mavis/reporting/templates/components/form_error_summary.jinja
@@ -1,0 +1,20 @@
+{% from "error-summary/macro.jinja" import errorSummary %}
+
+{% macro formErrorSummary(form) %}
+  {% set error_list = [] %}
+  {% for field, field_errors in form.errors.items() %}
+    {% for error in field_errors %}
+      {% set _ = error_list.append({
+        "text": error,
+        "href": "#" + field,
+      }) %}
+    {% endfor %}
+  {% endfor %}
+
+  {% if form.errors %}
+    {{ errorSummary({
+      "titleText": "There is a problem",
+      "errorList": error_list,
+    }) }}
+  {% endif %}
+{% endmacro %}

--- a/mavis/reporting/templates/components/secondary_navigation.jinja
+++ b/mavis/reporting/templates/components/secondary_navigation.jinja
@@ -16,4 +16,8 @@
   {% endfor %}
   </ul>
 </nav>
+
+<h2 class="nhsuk-u-visually-hidden">
+  {{ params["selected_item_text"] }}
+</h2>
 {% endmacro %}

--- a/mavis/reporting/templates/download.jinja
+++ b/mavis/reporting/templates/download.jinja
@@ -1,0 +1,22 @@
+{% from "components/heading.jinja" import heading %}
+{% from "back-link/macro.jinja" import backLink %}
+
+{% extends 'layouts/base.jinja' %}
+
+{% block pageTitle %}{{ organisation.name }} | {{ site_title }}{% endblock %}
+
+{% block beforeContent %}
+  {{ backLink({
+    "href": url_for("main.start_download", code=organisation.code),
+    "text": "Back"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+{{ heading({
+  "text": "Download data",
+  "level": "1",
+}) }}
+
+{% endblock %}

--- a/mavis/reporting/templates/download.jinja
+++ b/mavis/reporting/templates/download.jinja
@@ -1,5 +1,9 @@
 {% from "components/heading.jinja" import heading %}
 {% from "back-link/macro.jinja" import backLink %}
+{% from "radios/macro.jinja" import radios %}
+{% from "checkboxes/macro.jinja" import checkboxes %}
+{% from "button/macro.jinja" import button %}
+{% from "error-summary/macro.jinja" import errorSummary %}
 
 {% extends 'layouts/base.jinja' %}
 
@@ -18,5 +22,95 @@
   "text": "Download data",
   "level": "1",
 }) }}
+
+<p class="nhsuk-body-m nhsuk-u-margin-bottom-3">
+  Download vaccination and consent data for the {{ academic_year }} academic year so far.
+</p>
+
+<p class="nhsuk-body-m nhsuk-u-margin-bottom-6">
+  Last updated: {{ last_updated_time }}.
+</p>
+
+<form action="{{ url_for('main.download', code=organisation.code) }}" method="post">
+
+{{ form.csrf_token }}
+
+{% set error_list = [] %}
+{% for field, field_errors in form.errors.items() %}
+  {% for error in field_errors %}
+    {% set _ = error_list.append({
+      "text": error,
+      "href": "#" + field,
+    }) %}
+  {% endfor %}
+{% endfor %}
+
+{% if form.errors %}
+  {{ errorSummary({
+    "titleText": "There is a problem",
+    "errorList": error_list,
+  }) }}
+{% endif %}
+
+{% set items = [] %}
+{% for choice in form.programme.choices %}
+  {% set _ = items.append({
+    "value": choice[0],
+    "text": choice[1],
+  }) %}
+{% endfor %}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-u-margin-bottom-3 nhsuk-grid-column-two-thirds">
+    {{ radios({
+      "idPrefix": form.programme.id,
+      "name": form.programme.name,
+      "fieldset": {
+        "legend": {
+          "text": form.programme.label.text,
+          "classes": "nhsuk-fieldset__legend--s"
+        }
+      },
+      "errorMessage": {
+        "text": form.programme.errors[0],
+      } if form.programme.errors else "",
+      "items": items,
+    }) }}
+  </div>
+</div>
+
+{% set items = [] %}
+{% for choice in form.variables.choices %}
+  {% set _ = items.append({
+    "value": choice[0],
+    "text": choice[1],
+  }) %}
+{% endfor %}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-u-margin-bottom-3 nhsuk-grid-column-two-thirds">
+    {{ checkboxes({
+      "idPrefix": form.variables.name,
+      "name": form.variables.name,
+      "fieldset": {
+        "legend": {
+          "text": form.variables.label,
+          "classes": "nhsuk-fieldset__legend--s"
+        }
+      },
+      "errorMessage": {
+        "text": form.variables.errors[0],
+      } if form.variables.errors else "",
+      "items": items,
+    }) }}
+  </div>
+</div>
+
+{{ button({
+  "text": "Download",
+  "type": "submit",
+}) }}
+
+</form>
 
 {% endblock %}

--- a/mavis/reporting/templates/download.jinja
+++ b/mavis/reporting/templates/download.jinja
@@ -1,6 +1,7 @@
 {% from "components/heading.jinja" import heading %}
 {% from "radios/macro.jinja" import radios %}
 {% from "button/macro.jinja" import button %}
+{% from "error-summary/macro.jinja" import errorSummary %}
 
 {% extends 'layouts/dashboard.jinja' %}
 
@@ -10,27 +11,42 @@
 
 <form action="{{ url_for('main.download', code=organisation.code) }}" method="post">
 
+{% if form.errors %}
+  {{ errorSummary({
+    "titleText": "There is a problem",
+    "errorList": [
+      {
+        "text": form.data_type.errors[0],
+        "href": "#" + form.data_type.id,
+      }
+    ]}) }}
+{% endif %}
+
+{{ form.csrf_token }}
+
+{% set items = [] %}
+{% for choice in form.data_type.choices %}
+  {% set _ = items.append({
+    "value": choice[0],
+    "text": choice[1],
+  }) %}
+{% endfor %}
+
 <div class="nhsuk-grid-row">
   <div class="nhsuk-u-margin-bottom-3 nhsuk-grid-column-two-thirds">
     {{ radios({
-      "idPrefix": "download-type",
-      "name": "download-type",
+      "idPrefix": form.data_type.id,
+      "name": form.data_type.name,
       "fieldset": {
         "legend": {
-          "text": "What kind of data do you want to download?",
+          "text": form.data_type.label.text,
           "classes": "nhsuk-fieldset__legend--s"
         }
       },
-      "items": [
-        {
-          "text": "Child-level vaccination record data",
-          "value": "child-records",
-        },
-        {
-          "text": "Aggregate vaccination and consent data",
-          "value": "aggregate-data",
-        },
-      ],
+      "errorMessage": {
+        "text": form.data_type.errors[0],
+      } if form.data_type.errors else "",
+      "items": items,
     }) }}
   </div>
 </div>

--- a/mavis/reporting/templates/download.jinja
+++ b/mavis/reporting/templates/download.jinja
@@ -1,6 +1,5 @@
 {% from "components/heading.jinja" import heading %}
-{% from "select/macro.jinja" import select %}
-{% from "checkboxes/macro.jinja" import checkboxes %}
+{% from "radios/macro.jinja" import radios %}
 {% from "button/macro.jinja" import button %}
 
 {% extends 'layouts/dashboard.jinja' %}
@@ -9,84 +8,35 @@
 
 {% block dashboard_content %}
 
-{{ heading({
-  "text": "Download reporting data",
-  "level": 1,
-  "size": "xl",
-}) }}
-
-<div class="nhsuk-grid-row">
-  <div class="nhsuk-u-margin-bottom-3 nhsuk-grid-column-two-thirds">
-    <p>Download data for the number of vaccinations given to children in schools by month for your organisation.</p>
-  </div>
-</div>
-
 <form action="{{ url_for('main.download', code=organisation.code) }}" method="post">
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-u-margin-bottom-3 nhsuk-grid-column-two-thirds">
-    {{ heading({
-      "text": "Choose a programme",
-      "level": 2,
-      "size": "s",
-    }) }}
-
-    {% set programme_items = [] %}
-    {% for programme in programmes %}
-      {% set _ = programme_items.append({
-        "text": programme["name"],
-        "value": programme["code"],
-        "selected": programme["code"] == "hpv",
-      }) %}
-    {% endfor %}
-
-    {{ select({
-      "label": {
-        "text": "Programme",
-        "classes": "nhsuk-u-visually-hidden",
+    {{ radios({
+      "idPrefix": "download-type",
+      "name": "download-type",
+      "fieldset": {
+        "legend": {
+          "text": "What kind of data do you want to download?",
+          "classes": "nhsuk-fieldset__legend--s"
+        }
       },
-      "id": "programme",
-      "name": "programme",
-      "items": programmes,
-    }) }}
-  </div>
-</div>
-
-<div class="nhsuk-grid-row">
-  <div class="nhsuk-u-margin-bottom-3 nhsuk-grid-column-two-thirds">
-    {{ heading({
-      "text": "Choose other variables",
-      "level": 2,
-      "size": "s",
-    }) }}
-
-    {{ checkboxes({
-      "id": "variables",
-      "name": "variables",
       "items": [
         {
-          "text": "Local authority",
-          "value": "local_authority",
+          "text": "Child-level vaccination record data",
+          "value": "child-records",
         },
         {
-          "text": "School",
-          "value": "school",
+          "text": "Aggregate vaccination and consent data",
+          "value": "aggregate-data",
         },
-        {
-          "text": "Year group",
-          "value": "year_group",
-        },
-        {
-          "text": "Gender",
-          "value": "gender",
-        }
       ],
     }) }}
   </div>
 </div>
 
 {{ button({
-  "text": "Download data",
+  "text": "Continue",
   "type": "submit",
 }) }}
 

--- a/mavis/reporting/templates/download.jinja
+++ b/mavis/reporting/templates/download.jinja
@@ -3,7 +3,7 @@
 {% from "radios/macro.jinja" import radios %}
 {% from "checkboxes/macro.jinja" import checkboxes %}
 {% from "button/macro.jinja" import button %}
-{% from "error-summary/macro.jinja" import errorSummary %}
+{% from "components/form_error_summary.jinja" import formErrorSummary %}
 
 {% extends 'layouts/base.jinja' %}
 
@@ -35,22 +35,7 @@
 
 {{ form.csrf_token }}
 
-{% set error_list = [] %}
-{% for field, field_errors in form.errors.items() %}
-  {% for error in field_errors %}
-    {% set _ = error_list.append({
-      "text": error,
-      "href": "#" + field,
-    }) %}
-  {% endfor %}
-{% endfor %}
-
-{% if form.errors %}
-  {{ errorSummary({
-    "titleText": "There is a problem",
-    "errorList": error_list,
-  }) }}
-{% endif %}
+{{ formErrorSummary(form) }}
 
 {% set items = [] %}
 {% for choice in form.programme.choices %}

--- a/mavis/reporting/templates/layouts/base.jinja
+++ b/mavis/reporting/templates/layouts/base.jinja
@@ -25,6 +25,7 @@
       {
         "href": url_for('main.dashboard'),
         "text": "Reports",
+        "active": True,
       }
     ]
   },

--- a/mavis/reporting/templates/layouts/dashboard.jinja
+++ b/mavis/reporting/templates/layouts/dashboard.jinja
@@ -20,7 +20,8 @@
 }) }}
 
 {{ secondaryNavigation({
-  "items": secondary_navigation_items
+  "items": secondary_navigation_items,
+  "selected_item_text": selected_item_text,
 }) }}
 
 {% block dashboard_content %}

--- a/mavis/reporting/templates/start-download.jinja
+++ b/mavis/reporting/templates/start-download.jinja
@@ -9,7 +9,7 @@
 
 {% block dashboard_content %}
 
-<form action="{{ url_for('main.download', code=organisation.code) }}" method="post">
+<form action="{{ url_for('main.start_download', code=organisation.code) }}" method="post">
 
 {% if form.errors %}
   {{ errorSummary({

--- a/mavis/reporting/templates/start-download.jinja
+++ b/mavis/reporting/templates/start-download.jinja
@@ -1,7 +1,7 @@
 {% from "components/heading.jinja" import heading %}
 {% from "radios/macro.jinja" import radios %}
 {% from "button/macro.jinja" import button %}
-{% from "error-summary/macro.jinja" import errorSummary %}
+{% from "components/form_error_summary.jinja" import formErrorSummary %}
 
 {% extends 'layouts/dashboard.jinja' %}
 
@@ -11,18 +11,9 @@
 
 <form action="{{ url_for('main.start_download', code=organisation.code) }}" method="post">
 
-{% if form.errors %}
-  {{ errorSummary({
-    "titleText": "There is a problem",
-    "errorList": [
-      {
-        "text": form.data_type.errors[0],
-        "href": "#" + form.data_type.id,
-      }
-    ]}) }}
-{% endif %}
-
 {{ form.csrf_token }}
+
+{{ formErrorSummary(form) }}
 
 {% set items = [] %}
 {% for choice in form.data_type.choices %}

--- a/mavis/reporting/templates/start-download.jinja
+++ b/mavis/reporting/templates/start-download.jinja
@@ -5,7 +5,7 @@
 
 {% extends 'layouts/dashboard.jinja' %}
 
-{% block pageTitle %}{{ organisation.name }} | {{ site_title }}{% endblock %}
+{% block pageTitle %}Download vaccination data | {{ site_title }}{% endblock %}
 
 {% block dashboard_content %}
 

--- a/mavis/reporting/templates/vaccinations.jinja
+++ b/mavis/reporting/templates/vaccinations.jinja
@@ -5,7 +5,7 @@
 
 {% extends 'layouts/dashboard.jinja' %}
 
-{% block pageTitle %}Reports | {{ site_title }}{% endblock %}
+{% block pageTitle %}Vaccination report | {{ site_title }}{% endblock %}
 
 {% block dashboard_content %}
 

--- a/mavis/reporting/templates/vaccinations.jinja
+++ b/mavis/reporting/templates/vaccinations.jinja
@@ -50,9 +50,6 @@
           "descriptionHtml": "<p class='nhsuk-card__description'>" ~ data["vaccinated_percentage"] | percentage ~ "<span class='nhsuk-card__caption'>" ~ data["vaccinated"] | thousands ~ " children</span></p>",
         }) }}
       </div>
-    </div>
-
-    <div class="nhsuk-card-group nhsuk-grid-row app-card-group">
       <div class="nhsuk-grid-column-one-half nhsuk-card-group__item app-card-group__item">
         {{ card({
           "classes": "app-card",
@@ -72,9 +69,7 @@
           "descriptionHtml": "<p class='nhsuk-card__description'>" ~ data["vaccinated_previously_percentage"] | percentage ~ "<span class='nhsuk-card__caption'>" ~ data["vaccinated_previously"] | thousands ~ " children</span></p>",
         }) }}
       </div>
-    </div>
-
-    <div class="nhsuk-card-group nhsuk-grid-row app-card-group">
+      
       <div class="nhsuk-grid-column-one-half nhsuk-card-group__item app-card-group__item">
         {{ card({
           "classes": "app-card",

--- a/mavis/reporting/views.py
+++ b/mavis/reporting/views.py
@@ -59,7 +59,7 @@ def start_download(code):
         if form.data_type.data == DataTypeForm.CHILD_RECORDS:
             return redirect(current_app.config["MAVIS_ROOT_URL"] + "/programmes")
         elif form.data_type.data == DataTypeForm.AGGREGATE_DATA:
-            return redirect(url_for("main.start_download", code=organisation.code))
+            return redirect(url_for("main.download", code=organisation.code))
         else:
             raise ValueError("Invalid data type")
 
@@ -74,12 +74,26 @@ def start_download(code):
     return render_template(
         "start-download.jinja",
         organisation=organisation,
-        programmes=g.api_client.get_programmes(),
         academic_year=get_current_academic_year_range(),
         breadcrumb_items=breadcrumb_items,
         selected_item_text=selected_item_text,
         secondary_navigation_items=secondary_navigation_items,
         form=form,
+    )
+
+
+@main.route("/organisation/<code>/download")
+@auth_helper.login_required
+def download(code):
+    organisation = Organisation.get_from_session(session)
+    if organisation.code != code:
+        return redirect(url_for("main.download", code=organisation.code))
+
+    return render_template(
+        "download.jinja",
+        organisation=organisation,
+        programmes=g.api_client.get_programmes(),
+        academic_year=get_current_academic_year_range(),
     )
 
 

--- a/mavis/reporting/views.py
+++ b/mavis/reporting/views.py
@@ -46,12 +46,12 @@ def dashboard():
     return redirect(url_for("main.vaccinations", code=organisation.code))
 
 
-@main.route("/organisation/<code>/download", methods=["GET", "POST"])
+@main.route("/organisation/<code>/start-download", methods=["GET", "POST"])
 @auth_helper.login_required
-def download(code):
+def start_download(code):
     organisation = Organisation.get_from_session(session)
     if organisation.code != code:
-        return redirect(url_for("main.download", code=organisation.code))
+        return redirect(url_for("main.start_download", code=organisation.code))
 
     form = DataTypeForm()
 
@@ -59,7 +59,7 @@ def download(code):
         if form.data_type.data == DataTypeForm.CHILD_RECORDS:
             return redirect(current_app.config["MAVIS_ROOT_URL"] + "/programmes")
         elif form.data_type.data == DataTypeForm.AGGREGATE_DATA:
-            return redirect(url_for("main.download", code=organisation.code))
+            return redirect(url_for("main.start_download", code=organisation.code))
         else:
             raise ValueError("Invalid data type")
 
@@ -72,7 +72,7 @@ def download(code):
     )
 
     return render_template(
-        "download.jinja",
+        "start-download.jinja",
         organisation=organisation,
         programmes=g.api_client.get_programmes(),
         academic_year=get_current_academic_year_range(),

--- a/mavis/reporting/views.py
+++ b/mavis/reporting/views.py
@@ -13,6 +13,7 @@ from flask import (
 from healthcheck import HealthCheck
 
 from mavis.reporting.api_client.client import MavisApiClient
+from mavis.reporting.forms.data_type_form import DataTypeForm
 from mavis.reporting.helpers import auth_helper
 from mavis.reporting.helpers.breadcrumb_helper import generate_breadcrumb_items
 from mavis.reporting.helpers.date_helper import get_current_academic_year_range
@@ -52,8 +53,15 @@ def download(code):
     if organisation.code != code:
         return redirect(url_for("main.download", code=organisation.code))
 
-    if request.method == "POST":
-        return redirect(url_for("main.download", code=organisation.code))
+    form = DataTypeForm()
+
+    if request.method == "POST" and form.validate_on_submit():
+        if form.data_type.data == DataTypeForm.CHILD_RECORDS:
+            return redirect(current_app.config["MAVIS_ROOT_URL"] + "/programmes")
+        elif form.data_type.data == DataTypeForm.AGGREGATE_DATA:
+            return redirect(url_for("main.download", code=organisation.code))
+        else:
+            raise ValueError("Invalid data type")
 
     breadcrumb_items = generate_breadcrumb_items()
 
@@ -71,6 +79,7 @@ def download(code):
         breadcrumb_items=breadcrumb_items,
         selected_item_text=selected_item_text,
         secondary_navigation_items=secondary_navigation_items,
+        form=form,
     )
 
 

--- a/mavis/reporting/views.py
+++ b/mavis/reporting/views.py
@@ -56,6 +56,8 @@ def download(code):
         return redirect(url_for("main.download", code=organisation.code))
 
     breadcrumb_items = generate_breadcrumb_items()
+
+    selected_item_text = "Download"
     secondary_navigation_items = generate_secondary_nav_items(
         organisation.code,
         current_page="download",
@@ -67,6 +69,7 @@ def download(code):
         programmes=g.api_client.get_programmes(),
         academic_year=get_current_academic_year_range(),
         breadcrumb_items=breadcrumb_items,
+        selected_item_text=selected_item_text,
         secondary_navigation_items=secondary_navigation_items,
     )
 
@@ -79,6 +82,8 @@ def vaccinations(code):
         return redirect(url_for("main.vaccinations", code=organisation.code))
 
     breadcrumb_items = generate_breadcrumb_items()
+
+    selected_item_text = "Vaccinations"
     secondary_navigation_items = generate_secondary_nav_items(
         organisation.code,
         current_page="vaccinations",
@@ -107,6 +112,7 @@ def vaccinations(code):
         academic_year=get_current_academic_year_range(),
         data=data,
         breadcrumb_items=breadcrumb_items,
+        selected_item_text=selected_item_text,
         secondary_navigation_items=secondary_navigation_items,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "requests>=2.32.5",
     "pyjwt>=2.10.1",
     "sentry-sdk[flask]>=2.37.1",
+    "flask-wtf>=1.2.2",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -192,6 +192,20 @@ wheels = [
 ]
 
 [[package]]
+name = "flask-wtf"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flask" },
+    { name = "itsdangerous" },
+    { name = "wtforms" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/9b/f1cd6e41bbf874f3436368f2c7ee3216c1e82d666ff90d1d800e20eb1317/flask_wtf-1.2.2.tar.gz", hash = "sha256:79d2ee1e436cf570bccb7d916533fa18757a2f18c290accffab1b9a0b684666b", size = 42641, upload-time = "2024-10-24T07:18:58.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/19/354449145fbebb65e7c621235b6ad69bebcfaec2142481f044d0ddc5b5c5/flask_wtf-1.2.2-py3-none-any.whl", hash = "sha256:e93160c5c5b6b571cf99300b6e01b72f9a101027cab1579901f8b10c5daf0b70", size = 12779, upload-time = "2024-10-24T07:18:56.976Z" },
+]
+
+[[package]]
 name = "gunicorn"
 version = "23.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -257,6 +271,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },
+    { name = "flask-wtf" },
     { name = "gunicorn" },
     { name = "nhsuk-frontend-jinja" },
     { name = "py-healthcheck" },
@@ -279,6 +294,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "flask", specifier = "==3.1.2" },
+    { name = "flask-wtf", specifier = ">=1.2.2" },
     { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "nhsuk-frontend-jinja", specifier = "==0.4.1" },
     { name = "py-healthcheck", specifier = ">=1.10.1" },
@@ -591,4 +607,16 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925, upload-time = "2024-11-08T15:52:18.093Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498, upload-time = "2024-11-08T15:52:16.132Z" },
+]
+
+[[package]]
+name = "wtforms"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/e4/633d080897e769ed5712dcfad626e55dbd6cf45db0ff4d9884315c6a82da/wtforms-3.2.1.tar.gz", hash = "sha256:df3e6b70f3192e92623128123ec8dca3067df9cfadd43d59681e210cfb8d4682", size = 137801, upload-time = "2024-10-21T11:34:00.108Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/c9/2088fb5645cd289c99ebe0d4cdcc723922a1d8e1beaefb0f6f76dff9b21c/wtforms-3.2.1-py3-none-any.whl", hash = "sha256:583bad77ba1dd7286463f21e11aa3043ca4869d03575921d1a1698d0715e0fd4", size = 152454, upload-time = "2024-10-21T11:33:58.44Z" },
 ]


### PR DESCRIPTION
This PR reimplements the stub download page to establish a different flow and to use `Flask-WTF` (which itself uses [WTForms](https://github.com/pallets-eco/wtforms/)) for validation and CSRF protection.

- Adds an extra step in the "Download data" tab where a user first chooses whether they want child-level data or aggregate data
- Choosing child-level data redirects the user to the Mavis rails application (currently just the programmes tab, but this will have to change in future)
- Choosing aggregate data redirects the user to a download form where they choose a programme and select variables to break the data own by

If we're happy with this approach, I can add error-handling. It also is similar in approach to how Django Forms works, so should be straightforward to migrate if needed.

### Download tab

<img width="3072" height="2460" alt="Screen Shot 2025-09-28 at 18 03 08" src="https://github.com/user-attachments/assets/8d0367bb-5ad7-4af7-afc2-5e499b38010b" />

### Download tab with validation

<img width="3072" height="3180" alt="Screen Shot 2025-09-28 at 18 03 33" src="https://github.com/user-attachments/assets/401c3bb0-ffbe-4338-861f-6c32788dbd5a" />

### Aggregate download page

<img width="3072" height="3540" alt="Screen Shot 2025-09-28 at 18 04 08" src="https://github.com/user-attachments/assets/0563d478-e54e-4f49-83f8-4c1dfee0a5b0" />


