### PR TITLE
Allow filtering the reporting dashboard

### DIFF
--- a/mavis/reporting/api_client/client.py
+++ b/mavis/reporting/api_client/client.py
@@ -30,7 +30,23 @@ class MavisApiClient:
         return data
 
     def get_vaccination_data(self, filters=None):
-        params = filters or {}
+        params = {}
+
+        if filters:
+            filter_keys = [
+                "programme",
+                "gender",
+                "year_group",
+                "academic_year",
+                "team_id",
+                "local_authority",
+                "school_local_authority",
+            ]
+
+            for key in filter_keys:
+                if key in filters:
+                    params[key] = filters[key]
+
         response = mavis_helper.api_call(
             self.app, self.session, "/api/reporting/totals", params=params
         )
@@ -55,24 +71,25 @@ class MavisApiClient:
 
     def get_year_groups(self) -> list[dict]:
         return [
-            {"value": "0", "text": "Reception"},
-            {"value": "1", "text": "Year 1"},
-            {"value": "2", "text": "Year 2"},
-            {"value": "3", "text": "Year 3"},
-            {"value": "4", "text": "Year 4"},
-            {"value": "5", "text": "Year 5"},
-            {"value": "6", "text": "Year 6"},
-            {"value": "7", "text": "Year 7"},
-            {"value": "8", "text": "Year 8"},
-            {"value": "9", "text": "Year 9"},
-            {"value": "10", "text": "Year 10"},
-            {"value": "11", "text": "Year 11"},
+            {"value": "5", "text": "Reception"},
+            {"value": "6", "text": "Year 1"},
+            {"value": "7", "text": "Year 2"},
+            {"value": "8", "text": "Year 3"},
+            {"value": "9", "text": "Year 4"},
+            {"value": "10", "text": "Year 5"},
+            {"value": "11", "text": "Year 6"},
+            {"value": "12", "text": "Year 7"},
+            {"value": "13", "text": "Year 8"},
+            {"value": "14", "text": "Year 9"},
+            {"value": "15", "text": "Year 10"},
+            {"value": "16", "text": "Year 11"},
         ]
 
+    # https://www.datadictionary.nhs.uk/attributes/person_gender_code.html
     def get_genders(self) -> list[dict]:
         return [
-            {"value": "female", "text": "Female"},
-            {"value": "male", "text": "Male"},
-            {"value": "other", "text": "Other"},
-            {"value": "unknown", "text": "Unknown"},
+            {"value": "2", "text": "Female"},
+            {"value": "1", "text": "Male"},
+            {"value": "9", "text": "Other"},
+            {"value": "0", "text": "Unknown"},
         ]

--- a/mavis/reporting/assets/scss/_button.scss
+++ b/mavis/reporting/assets/scss/_button.scss
@@ -1,0 +1,7 @@
+@use "config" as *;
+
+.app-button--small {
+  padding: nhsuk-spacing(2) 12px nhsuk-spacing(1);
+
+  @include nhsuk-font-size(16);
+}

--- a/mavis/reporting/assets/scss/app.scss
+++ b/mavis/reporting/assets/scss/app.scss
@@ -5,3 +5,4 @@
 @use "app_card";
 @use "secondary_navigation";
 @use "data_table";
+@use "button";

--- a/mavis/reporting/helpers/mavis_helper.py
+++ b/mavis/reporting/helpers/mavis_helper.py
@@ -12,7 +12,7 @@ def mavis_url(current_app, path, params={}):
     url = urllib.parse.urljoin(current_app.config["MAVIS_ROOT_URL"], path)
     if params != {}:
         parsed_url = urllib.parse.urlsplit(url)
-        query_string = urllib.parse.urlencode(params)
+        query_string = urllib.parse.urlencode(params, doseq=True)
         url_with_params = parsed_url._replace(query=query_string)
         url = urllib.parse.urlunsplit(url_with_params)
 

--- a/mavis/reporting/templates/components/filters.jinja
+++ b/mavis/reporting/templates/components/filters.jinja
@@ -3,9 +3,10 @@
 {% from "checkboxes/macro.jinja" import checkboxes %}
 {% from "input/macro.jinja" import input %}
 {% from "fieldset/macro.jinja" import fieldset %}
+{% from "button/macro.jinja" import button %}
 
 {% macro filters(params) %}
-<form>
+<form method="get" action="{{ params.form_action }}">
   {% call fieldset({
     "legend": {
       "text": "Filter data",
@@ -16,6 +17,23 @@
   }) %}
 
     <div class="filter">
+      {{ button({
+        "text": "Apply filters",
+        "classes": "nhsuk-button--secondary"
+      }) }}
+    </div>
+
+    <div class="filter">
+      {% set programme_items = [] %}
+      {% for programme in params.programmes %}
+        {% set checked = params.current_filters.get('programme') == programme.value %}
+        {% set _ = programme_items.append({
+          "value": programme.value,
+          "text": programme.text,
+          "checked": checked
+        }) %}
+      {% endfor %}
+
       {{ radios({
         "idPrefix": "programme",
         "name": "programme",
@@ -25,11 +43,21 @@
             "classes": "nhsuk-fieldset__legend--s"
           }
         },
-        "items": params.programmes
+        "items": programme_items
       }) }}
     </div>
 
     <div class="filter">
+      {% set gender_items = [] %}
+      {% for gender in params.genders %}
+        {% set checked = gender.value in (params.current_filters.get('gender') or []) %}
+        {% set _ = gender_items.append({
+          "value": gender.value,
+          "text": gender.text,
+          "checked": checked
+        }) %}
+      {% endfor %}
+
       {{ checkboxes({
         "idPrefix": "gender",
         "name": "gender",
@@ -39,11 +67,21 @@
             "classes": "nhsuk-fieldset__legend--s"
           }
         },
-        "items": params.genders
+        "items": gender_items
       }) }}
     </div>
 
     <div class="filter">
+      {% set year_group_items = [] %}
+      {% for year_group in params.year_groups %}
+        {% set checked = year_group.value in (params.current_filters.get('year_group') or []) %}
+        {% set _ = year_group_items.append({
+          "value": year_group.value,
+          "text": year_group.text,
+          "checked": checked
+        }) %}
+      {% endfor %}
+
       {{ checkboxes({
         "idPrefix": "year-group",
         "name": "year-group",
@@ -53,7 +91,7 @@
             "classes": "nhsuk-fieldset__legend--s"
           }
         },
-        "items": params.year_groups
+        "items": year_group_items
       }) }}
     </div>
   {% endcall %}

--- a/mavis/reporting/templates/components/filters.jinja
+++ b/mavis/reporting/templates/components/filters.jinja
@@ -93,6 +93,12 @@
         "text": "Update results",
         "classes": "nhsuk-button--secondary app-button--small"
       }) }}
+
+      {{ button({
+        "text": "Clear filters",
+        "classes": "nhsuk-button--secondary app-button--small",
+        "href": params.form_action
+      }) }}
     </div>
   {% endcall %}
 </form>

--- a/mavis/reporting/templates/components/filters.jinja
+++ b/mavis/reporting/templates/components/filters.jinja
@@ -17,13 +17,6 @@
   }) %}
 
     <div class="filter">
-      {{ button({
-        "text": "Apply filters",
-        "classes": "nhsuk-button--secondary"
-      }) }}
-    </div>
-
-    <div class="filter">
       {% set programme_items = [] %}
       {% for programme in params.programmes %}
         {% set checked = params.current_filters.get('programme') == programme.value %}
@@ -92,6 +85,13 @@
           }
         },
         "items": year_group_items
+      }) }}
+    </div>
+
+    <div class="nhsuk-button-group">
+      {{ button({
+        "text": "Update results",
+        "classes": "nhsuk-button--secondary app-button--small"
       }) }}
     </div>
   {% endcall %}

--- a/mavis/reporting/templates/vaccinations.jinja
+++ b/mavis/reporting/templates/vaccinations.jinja
@@ -14,7 +14,9 @@
     {{ filters({
       "programmes": programmes,
       "year_groups": year_groups,
-      "genders": genders
+      "genders": genders,
+      "current_filters": current_filters or {},
+      "form_action": url_for('main.vaccinations', code=organisation.code)
     }) }}
   </div>
 

--- a/mavis/reporting/views.py
+++ b/mavis/reporting/views.py
@@ -126,16 +126,21 @@ def vaccinations(code):
     )
 
     filters = {}
+    current_filters = {}
+
     if request.args.get("programme"):
         filters["programme"] = request.args.get("programme")
-    if request.args.get("year_group"):
-        filters["year_group"] = request.args.get("year_group")
-    if request.args.get("gender"):
-        filters["gender"] = request.args.get("gender")
-    if request.args.get("from_date"):
-        filters["from_date"] = request.args.get("from_date")
-    if request.args.get("to_date"):
-        filters["to_date"] = request.args.get("to_date")
+        current_filters["programme"] = request.args.get("programme")
+
+    gender_values = request.args.getlist("gender")
+    if gender_values:
+        filters["gender"] = gender_values
+        current_filters["gender"] = gender_values
+
+    year_group_values = request.args.getlist("year-group")
+    if year_group_values:
+        filters["year_group"] = year_group_values
+        current_filters["year_group"] = year_group_values
 
     data = g.api_client.get_vaccination_data(filters)
 
@@ -147,6 +152,7 @@ def vaccinations(code):
         genders=g.api_client.get_genders(),
         academic_year=get_current_academic_year_range(),
         data=data,
+        current_filters=current_filters,
         breadcrumb_items=breadcrumb_items,
         selected_item_text=selected_item_text,
         secondary_navigation_items=secondary_navigation_items,


### PR DESCRIPTION
This wires up the checkboxes and radio buttons in the frontend to the request that goes to the Totals API in Mavis.

It also adds a button to apply the filters, which will be visible in situations where JS fails to load. It also adds a button to clear the filters.

The year group filter is only partially working at the moment, but it's because it's not being handled on the Mavis side, which can be done as a follow-up.

A follow-up PR will add JS to make the form feel better to use, by submitting it without needing to use the button, and by replacing the content of the dashboard in-place.

<img width="3540" height="5310" alt="Screen Shot 2025-09-29 at 21 20 20" src="https://github.com/user-attachments/assets/42ae66af-8366-4bf5-bb54-5c04336b418d" />
