### PR TITLE
Use htmx to progressively enhance dashboard

### DIFF
--- a/mavis/reporting/assets/scss/app.scss
+++ b/mavis/reporting/assets/scss/app.scss
@@ -6,3 +6,7 @@
 @use "secondary_navigation";
 @use "data_table";
 @use "button";
+
+.js-enabled .js-hide {
+  display: none;
+}

--- a/mavis/reporting/javascript/app.js
+++ b/mavis/reporting/javascript/app.js
@@ -1,3 +1,4 @@
 import { createAll, Header } from "nhsuk-frontend";
+import "htmx.org";
 
 createAll(Header);

--- a/mavis/reporting/templates/components/filters.jinja
+++ b/mavis/reporting/templates/components/filters.jinja
@@ -6,7 +6,15 @@
 {% from "button/macro.jinja" import button %}
 
 {% macro filters(params) %}
-<form method="get" action="{{ params.form_action }}">
+<form method="get"
+      action="{{ params.form_action }}"
+      hx-get="{{ params.form_action }}"
+      hx-trigger="change from:input"
+      hx-target="#dashboard"
+      hx-select="#dashboard"
+      hx-swap="outerHTML"
+      hx-replace-url="true"
+      hx-sync="this:replace">
   {% call fieldset({
     "legend": {
       "text": "Filter data",
@@ -91,7 +99,7 @@
     <div class="nhsuk-button-group">
       {{ button({
         "text": "Update results",
-        "classes": "nhsuk-button--secondary app-button--small"
+        "classes": "nhsuk-button--secondary app-button--small js-hide"
       }) }}
 
       {{ button({

--- a/mavis/reporting/templates/vaccinations.jinja
+++ b/mavis/reporting/templates/vaccinations.jinja
@@ -20,7 +20,7 @@
     }) }}
   </div>
 
-  <div class="app-grid-column-content">
+  <div id="dashboard" class="app-grid-column-content">
 
     <div class="nhsuk-card-group nhsuk-grid-row app-card-group">
       <div class="nhsuk-grid-column-one-third nhsuk-card-group__item app-card-group__item">
@@ -71,7 +71,7 @@
           "descriptionHtml": "<p class='nhsuk-card__description'>" ~ data["vaccinated_previously_percentage"] | percentage ~ "<span class='nhsuk-card__caption'>" ~ data["vaccinated_previously"] | thousands ~ " children</span></p>",
         }) }}
       </div>
-      
+
       <div class="nhsuk-grid-column-one-half nhsuk-card-group__item app-card-group__item">
         {{ card({
           "classes": "app-card",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "manage-vaccinations-in-schools-reporting",
       "dependencies": {
+        "htmx.org": "^2.0.7",
         "nhsuk-frontend": "^10.0.0"
       },
       "devDependencies": {
@@ -864,6 +865,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/htmx.org": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.7.tgz",
+      "integrity": "sha512-YiJqF3U5KyO28VC5mPfehKJPF+n1Gni+cupK+D69TF0nm7wY6AXn3a4mPWIikfAXtl1u1F1+ZhSCS7KT8pVmqA==",
+      "license": "0BSD"
     },
     "node_modules/immutable": {
       "version": "5.1.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build:js:dev": "esbuild mavis/reporting/javascript/app.js --bundle --outfile=mavis/reporting/static/js/app.js --sourcemap --minify --watch=forever"
   },
   "dependencies": {
+    "htmx.org": "^2.0.7",
     "nhsuk-frontend": "^10.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This adds `hx-` attributes to the form to trigger a GET request to the same form endpoint whenever the inputs change. HTMX intercepts this request, extracts the `#dashboard`, and replaces the `#dashboard` in the same page.

We also add a `js-hide` CSS class that hides the "Update results" button if JS is enabled.