### PR TITLE
 Encode multiple year groups with square brackets

### DIFF
--- a/mavis/reporting/api_client/client.py
+++ b/mavis/reporting/api_client/client.py
@@ -71,18 +71,18 @@ class MavisApiClient:
 
     def get_year_groups(self) -> list[dict]:
         return [
-            {"value": "5", "text": "Reception"},
-            {"value": "6", "text": "Year 1"},
-            {"value": "7", "text": "Year 2"},
-            {"value": "8", "text": "Year 3"},
-            {"value": "9", "text": "Year 4"},
-            {"value": "10", "text": "Year 5"},
-            {"value": "11", "text": "Year 6"},
-            {"value": "12", "text": "Year 7"},
-            {"value": "13", "text": "Year 8"},
-            {"value": "14", "text": "Year 9"},
-            {"value": "15", "text": "Year 10"},
-            {"value": "16", "text": "Year 11"},
+            {"value": "0", "text": "Reception"},
+            {"value": "1", "text": "Year 1"},
+            {"value": "2", "text": "Year 2"},
+            {"value": "3", "text": "Year 3"},
+            {"value": "4", "text": "Year 4"},
+            {"value": "5", "text": "Year 5"},
+            {"value": "6", "text": "Year 6"},
+            {"value": "7", "text": "Year 7"},
+            {"value": "8", "text": "Year 8"},
+            {"value": "9", "text": "Year 9"},
+            {"value": "10", "text": "Year 10"},
+            {"value": "11", "text": "Year 11"},
         ]
 
     # https://www.datadictionary.nhs.uk/attributes/person_gender_code.html

--- a/mavis/reporting/helpers/mavis_helper.py
+++ b/mavis/reporting/helpers/mavis_helper.py
@@ -12,7 +12,16 @@ def mavis_url(current_app, path, params={}):
     url = urllib.parse.urljoin(current_app.config["MAVIS_ROOT_URL"], path)
     if params != {}:
         parsed_url = urllib.parse.urlsplit(url)
-        query_string = urllib.parse.urlencode(params, doseq=True)
+
+        encoded_params = []
+        for key, value in params.items():
+            if isinstance(value, list):
+                for item in value:
+                    encoded_params.append((f"{key}[]", item))
+            else:
+                encoded_params.append((key, value))
+
+        query_string = urllib.parse.urlencode(encoded_params)
         url_with_params = parsed_url._replace(query=query_string)
         url = urllib.parse.urlunsplit(url_with_params)
 

--- a/tests/helpers/test_mavis_helper.py
+++ b/tests/helpers/test_mavis_helper.py
@@ -53,6 +53,15 @@ def test_that_mavis_url_applies_url_encoding_to_params(app):
         )
 
 
+def test_mavis_url_with_list_params(app):
+    with app.app_context():
+        app.config["MAVIS_ROOT_URL"] = "http://i.am.mavis:4000/"
+        url = mavis_helper.mavis_url(
+            current_app, "/some/path.json", {"year_group": ["8", "9"]}
+        )
+        assert url == "http://i.am.mavis:4000/some/path.json?year_group%5B%5D=8&year_group%5B%5D=9"
+
+
 class MockResponse:
     def __init__(self, **kwargs):
         self.status_code = kwargs.get("status_code", None)


### PR DESCRIPTION
Mavis expects `year_group[]=8&year_group[]=9`, whereas we were passing it `year_group=8&year_group=9`.

Also the API has been fixed and now correctly generates `year_groups`, so we can use the more natural 0-based indexing.
