### PR TITLE
Add environment header to match Mavis

### DIFF
--- a/mavis/reporting/__init__.py
+++ b/mavis/reporting/__init__.py
@@ -29,10 +29,13 @@ if dsn := os.environ.get("SENTRY_DSN"):
 
 def create_app(config_name=None):
     if config_name is None:
-        config_name = os.environ["FLASK_ENV"]
+        config_name = os.environ["FLASK_ENV"].lower().strip()
 
     app = Flask(__name__, static_url_path="/reporting/assets")
-    app.config.from_object(config[config_name])
+    try:
+        app.config.from_object(config[config_name])
+    except KeyError:
+        app.config.from_object(config["default"])
 
     # Set cache timeout for static files (1 hour in development, 1 year in production)
     if config_name == "development":

--- a/mavis/reporting/assets/scss/_environment.scss
+++ b/mavis/reporting/assets/scss/_environment.scss
@@ -1,0 +1,18 @@
+@use "config" as *;
+
+.app-environment {
+  @include nhsuk-font-size(14);
+  @include nhsuk-responsive-padding(2, bottom);
+  @include nhsuk-responsive-padding(2, top);
+
+  .nhsuk-link {
+    color: inherit;
+  }
+
+  .nhsuk-width-container {
+    align-items: baseline;
+    display: flex;
+    flex-wrap: wrap;
+    gap: nhsuk-spacing(1) nhsuk-spacing(2);
+  }
+}

--- a/mavis/reporting/assets/scss/app.scss
+++ b/mavis/reporting/assets/scss/app.scss
@@ -6,6 +6,7 @@
 @use "secondary_navigation";
 @use "data_table";
 @use "button";
+@use "environment";
 
 .js-enabled .js-hide {
   display: none;

--- a/mavis/reporting/config/__init__.py
+++ b/mavis/reporting/config/__init__.py
@@ -1,5 +1,7 @@
 import os
 
+from mavis.reporting.helpers.environment_helper import EnvType
+
 
 def str2bool(v):
     return v is not None and v.lower() in ("yes", "true", "t", "1")
@@ -28,6 +30,7 @@ class Config:
 class DevelopmentConfig(Config):
     """Development configuration"""
 
+    ENVIRONMENT = EnvType.DEV
     DEBUG = True
     TESTING = False
     LOG_LEVEL = "DEBUG"
@@ -36,6 +39,7 @@ class DevelopmentConfig(Config):
 class ProductionConfig(Config):
     """Production configuration"""
 
+    ENVIRONMENT = EnvType.PROD
     DEBUG = False
     TESTING = False
     LOG_LEVEL = "INFO"
@@ -44,6 +48,7 @@ class ProductionConfig(Config):
 class StagingConfig(Config):
     """Staging configuration - for sandbox-alpha/-beta"""
 
+    ENVIRONMENT = EnvType.STAGING
     DEBUG = False
     TESTING = False
     LOG_LEVEL = "INFO"
@@ -52,14 +57,15 @@ class StagingConfig(Config):
 class TestingConfig(Config):
     """Testing configuration"""
 
+    ENVIRONMENT = EnvType.TEST
     TESTING = True
     DEBUG = True
 
 
 config = {
-    "development": DevelopmentConfig,
-    "production": ProductionConfig,
-    "testing": TestingConfig,
-    "staging": StagingConfig,
-    "default": DevelopmentConfig,
+    EnvType.DEV.value: DevelopmentConfig,
+    EnvType.PROD.value: ProductionConfig,
+    EnvType.STAGING.value: StagingConfig,
+    EnvType.TEST.value: TestingConfig,
+    "default": ProductionConfig,
 }

--- a/mavis/reporting/helpers/environment_helper.py
+++ b/mavis/reporting/helpers/environment_helper.py
@@ -1,0 +1,48 @@
+from enum import Enum
+
+
+class EnvType(Enum):
+    PROD = "production"
+    DEV = "development"
+    REVIEW = "review"
+    STAGING = "staging"
+    TEST = "test"
+    QA = "qa"
+    PREVIEW = "preview"
+
+    def __str__(self):
+        return str(self.value)
+
+
+ENV_COLOUR = {
+    EnvType.PROD: "blue",
+    EnvType.DEV: "white",
+    EnvType.REVIEW: "purple",
+    EnvType.STAGING: "purple",
+    EnvType.TEST: "red",
+    EnvType.QA: "orange",
+    EnvType.PREVIEW: "yellow",
+}
+
+
+class Environment:
+    def __init__(self, type: EnvType):
+        self.type = type
+
+    def is_production(self):
+        return self.type == EnvType.PROD
+
+    @property
+    def colour(self):
+        return ENV_COLOUR[self.type]
+
+    @property
+    def title(self):
+        return str(self.type).capitalize()
+
+    @property
+    def title_in_sentence(self):
+        return (
+            f"This is a {self.type} environment."
+            + " Do not use it to make clinical decisions."
+        )

--- a/mavis/reporting/templates/components/environment.jinja
+++ b/mavis/reporting/templates/components/environment.jinja
@@ -1,0 +1,13 @@
+{% from "tag/macro.jinja" import tag %}
+
+{% macro environment(params) %}
+<div class="app-environment nhsuk-tag--{{ params.colour }}">
+  <div class="nhsuk-width-container">
+    {{ tag({
+      "classes": "nhsuk-tag--" + params.colour,
+      "text": params.title,
+    }) }}
+    <span>{{ params.title_in_sentence | safe }}</span>
+  </div>
+</div>
+{% endmacro %}

--- a/mavis/reporting/templates/download.jinja
+++ b/mavis/reporting/templates/download.jinja
@@ -7,7 +7,7 @@
 
 {% extends 'layouts/base.jinja' %}
 
-{% block pageTitle %}{{ organisation.name }} | {{ site_title }}{% endblock %}
+{% block pageTitle %}{{ organisation.name }} | {{ app_title }}{% endblock %}
 
 {% block beforeContent %}
   {{ backLink({

--- a/mavis/reporting/templates/layouts/base.jinja
+++ b/mavis/reporting/templates/layouts/base.jinja
@@ -1,5 +1,6 @@
 
 {% from 'header/macro.jinja' import header %}
+{% from 'components/environment.jinja' import environment %}
 {% extends 'nhsuk/template.jinja' %}
 
 {% block headIcons %}
@@ -15,6 +16,12 @@
 {% endblock %}
 
 {% block header %}
+{{ environment({
+  "colour": app_environment.colour,
+  "title": app_environment.title,
+  "title_in_sentence": app_environment.title_in_sentence,
+}) if not app_environment.is_production() }}
+
 {{ header({
   "service": {
     "text": "Manage vaccinations in schools",

--- a/mavis/reporting/templates/vaccinations.jinja
+++ b/mavis/reporting/templates/vaccinations.jinja
@@ -5,7 +5,7 @@
 
 {% extends 'layouts/dashboard.jinja' %}
 
-{% block pageTitle %}Vaccination report | {{ site_title }}{% endblock %}
+{% block pageTitle %}Vaccination report | {{ app_title }}{% endblock %}
 
 {% block dashboard_content %}
 

--- a/mavis/reporting/views.py
+++ b/mavis/reporting/views.py
@@ -21,6 +21,7 @@ from mavis.reporting.helpers.date_helper import (
     get_current_academic_year_range,
     get_last_updated_time,
 )
+from mavis.reporting.helpers.environment_helper import Environment
 from mavis.reporting.helpers.secondary_nav_helper import generate_secondary_nav_items
 from mavis.reporting.models.organisation import Organisation
 
@@ -37,8 +38,10 @@ def stub_mavis_data():
 @main.context_processor
 def inject_mavis_data():
     """Inject common data into the template context."""
+    env = Environment(current_app.config["ENVIRONMENT"])
     return {
-        "site_title": "Manage vaccinations in schools",
+        "app_title": "Manage vaccinations in schools",
+        "app_environment": env,
     }
 
 

--- a/tests/helpers/test_environment_helper.py
+++ b/tests/helpers/test_environment_helper.py
@@ -1,0 +1,37 @@
+from mavis.reporting.helpers.environment_helper import (
+    Environment,
+    EnvType,
+)
+
+
+def test_environment_is_production_behaviour():
+    """Test that is_production behaves correctly for different environments."""
+    assert Environment(EnvType.PROD).is_production() is True
+    assert Environment(EnvType.DEV).is_production() is False
+    assert Environment(EnvType.STAGING).is_production() is False
+    assert Environment(EnvType.TEST).is_production() is False
+
+
+def test_environment_colour_property():
+    """Test that colour property returns correct color for each environment."""
+    assert Environment(EnvType.PROD).colour == "blue"
+    assert Environment(EnvType.DEV).colour == "white"
+    assert Environment(EnvType.STAGING).colour == "purple"
+    assert Environment(EnvType.TEST).colour == "red"
+
+
+def test_environment_title_property():
+    """Test that title property returns capitalized environment type."""
+    assert Environment(EnvType.PROD).title == "Production"
+    assert Environment(EnvType.DEV).title == "Development"
+    assert Environment(EnvType.STAGING).title == "Staging"
+
+
+def test_environment_title_in_sentence_property():
+    """Test that title_in_sentence property returns correct warning message."""
+    title_in_sentence = Environment(EnvType.DEV).title_in_sentence
+    assert (
+        title_in_sentence
+        == "This is a development environment."
+        + " Do not use it to make clinical decisions."
+    )


### PR DESCRIPTION
Also changes app initialisation so that if the environment passed in `FLASK_ENV` is unrecognised, the app loads in production instead of crashing.

<img width="1558" height="740" alt="Screenshot 2025-10-05 at 17 48 19" src="https://github.com/user-attachments/assets/04af8795-5942-40f2-b5f2-3cafad28df20" />
