### PR TITLE
Rename reporting to reports in URLs

### DIFF
--- a/mavis/reporting/__init__.py
+++ b/mavis/reporting/__init__.py
@@ -31,7 +31,7 @@ def create_app(config_name=None):
     if config_name is None:
         config_name = os.environ["FLASK_ENV"].lower().strip()
 
-    app = Flask(__name__, static_url_path="/reporting/assets")
+    app = Flask(__name__, static_url_path="/reports/assets")
     try:
         app.config.from_object(config[config_name])
     except KeyError:
@@ -48,10 +48,10 @@ def create_app(config_name=None):
     # ruff: noqa: PLC0415
     from mavis.reporting.views import main
 
-    app.register_blueprint(main, url_prefix="/reporting")
+    app.register_blueprint(main, url_prefix="/reports")
 
     @app.route("/")
     def root():
-        return redirect("/reporting")
+        return redirect("/reports")
 
     return app

--- a/mavis/reporting/config/jinja2.py
+++ b/mavis/reporting/config/jinja2.py
@@ -3,6 +3,7 @@ import os
 from jinja2 import ChainableUndefined, ChoiceLoader, FileSystemLoader, PackageLoader
 
 from mavis.reporting.helpers.date_helper import format_date_string
+from mavis.reporting.helpers.mavis_helper import mavis_url
 from mavis.reporting.helpers.number_helper import percentage, thousands
 from mavis.reporting.helpers.static_file_helper import static
 
@@ -27,8 +28,10 @@ def configure_jinja2(app):
         ),
     }
 
-    # Add the static function to allow for cache busting of static files
+    # Add functions for cache busting of static files
+    # and for generating Mavis URLs
     app.jinja_env.globals["static"] = static
+    app.jinja_env.globals["mavis_url"] = lambda path: mavis_url(app, path)
 
     # Add custom filters
     app.jinja_env.filters["thousands"] = thousands

--- a/mavis/reporting/templates/layouts/base.jinja
+++ b/mavis/reporting/templates/layouts/base.jinja
@@ -25,7 +25,7 @@
 {{ header({
   "service": {
     "text": "Manage vaccinations in schools",
-    "href": url_for('main.dashboard')
+    "href": mavis_url("/dashboard")
   },
   "navigation": {
     "items": [

--- a/mise.staging.toml
+++ b/mise.staging.toml
@@ -12,5 +12,5 @@ _.file = "{{vars.credentials_file}}"
 
 FLASK_ENV = "staging"
 MAVIS_ROOT_URL = "https://sandbox-alpha.mavistesting.com/"
-ROOT_URL = "https://sandbox-alpha.mavistesting.com/reporting/"
+ROOT_URL = "https://sandbox-alpha.mavistesting.com/reports/"
 SESSION_TTL_SECONDS = "600"

--- a/tests/auth/test_auth.py
+++ b/tests/auth/test_auth.py
@@ -8,7 +8,7 @@ from tests.helpers import mock_user_info
 
 
 def default_url():
-    return "/reporting/organisation/R1L/vaccinations"
+    return "/reports/organisation/R1L/vaccinations"
 
 
 def it_redirects_to_mavis_start(response):

--- a/tests/helpers/test_url_helper.py
+++ b/tests/helpers/test_url_helper.py
@@ -36,23 +36,23 @@ def test_url_without_param(input_url, param, expected):
 
 def test_externalise_url_uses_root_url(app):
     request = MockRequest(
-        host_url="http://my.server/", full_path="/reporting/full/path?query=val1"
+        host_url="http://my.server/", full_path="/reports/full/path?query=val1"
     )
-    app.config["ROOT_URL"] = "https://mavis.test/reporting"
+    app.config["ROOT_URL"] = "https://mavis.test/reportsg"
 
     assert (
         url_helper.externalise_current_url(app, request)
-        == "https://mavis.test/reporting/full/path?query=val1"
+        == "https://mavis.test/reports/full/path?query=val1"
     )
 
 
 def test_externalise_url_uses_host_url(app):
     request = MockRequest(
-        host_url="http://my.server/", full_path="/reporting/full/path?query=val1"
+        host_url="http://my.server/", full_path="/reports/full/path?query=val1"
     )
     app.config["ROOT_URL"] = None
 
     assert (
         url_helper.externalise_current_url(app, request)
-        == "http://my.server/reporting/full/path?query=val1"
+        == "http://my.server/reports/full/path?query=val1"
     )


### PR DESCRIPTION
Rename `reporting` to `reports` in URLs to match the user-facing rename in the UI and in the infrastructure PR in the main Mavis repo.

Also change logo to link to main Mavis homepage.