### PR TITLE
Align header navigation items to Mavis

### DIFF
--- a/mavis/reporting/templates/layouts/base.jinja
+++ b/mavis/reporting/templates/layouts/base.jinja
@@ -31,8 +31,43 @@
     "items": [
       {
         "href": url_for('main.dashboard'),
-        "text": "Reports",
+        "text": "Programmes",
         "active": True,
+      },
+      {
+        "href": mavis_url("/sessions"),
+        "text": "Sessions",
+        "active": False,
+      },
+      {
+        "href": mavis_url("/patients"),
+        "text": "Children",
+        "active": False,
+      },
+      {
+        "href": mavis_url("/consent-forms"),
+        "text": "Unmatched responses",
+        "active": False,
+      },
+      {
+        "href": mavis_url("/school_moves"),
+        "text": "School moves",
+        "active": False,
+      },
+      {
+        "href": mavis_url("/vaccines"),
+        "text": "Vaccines",
+        "active": False,
+      },
+      {
+        "href": mavis_url("/imports"),
+        "text": "Imports",
+        "active": False,
+      },
+      {
+        "href": mavis_url("/team"),
+        "text": "Your team",
+        "active": False,
       }
     ]
   },


### PR DESCRIPTION
Hard-code the navigation items from Mavis, as they're unlikely to change too often.

The counts will be added in a follow-up.

<img width="1219" height="651" alt="498145471-f2e4ebc7-ed2c-4c94-adf2-cc0e2ad280cf" src="https://github.com/user-attachments/assets/a643013c-8c56-4b11-9009-72ed776cc5a0" />
