### PR TITLE
Proxy requests to Mavis in development

### DIFF
--- a/mavis/reporting/config/__init__.py
+++ b/mavis/reporting/config/__init__.py
@@ -34,6 +34,7 @@ class DevelopmentConfig(Config):
     DEBUG = True
     TESTING = False
     LOG_LEVEL = "DEBUG"
+    MAVIS_BACKEND_URL = os.environ["MAVIS_BACKEND_URL"]
 
 
 class ProductionConfig(Config):

--- a/mavis/reporting/dev_proxy.py
+++ b/mavis/reporting/dev_proxy.py
@@ -1,0 +1,43 @@
+import requests
+from flask import Response, current_app, request
+
+
+def proxy_to_mavis(path):
+    backend_url = current_app.config["MAVIS_BACKEND_URL"]
+    proxy_url = request.host_url.rstrip("/")
+
+    url = f"{backend_url}/{path}"
+    if request.query_string:
+        url += f"?{request.query_string.decode()}"
+
+    headers = {k: v for k, v in request.headers if k.lower() != "host"}
+
+    # Rewrite Origin and Referer headers for Rails CSRF validation
+    if "Origin" in headers:
+        headers["Origin"] = backend_url
+    if "Referer" in headers:
+        headers["Referer"] = headers["Referer"].replace(proxy_url, backend_url)
+
+    resp = requests.request(
+        method=request.method,
+        url=url,
+        headers=headers,
+        data=request.get_data(),
+        cookies=request.cookies,
+        allow_redirects=False,
+        stream=True,
+    )
+
+    excluded_headers = [
+        "content-encoding",
+        "content-length",
+        "transfer-encoding",
+        "connection",
+    ]
+    response_headers = [
+        (k, v)
+        for k, v in resp.raw.headers.items()
+        if k.lower() not in excluded_headers
+    ]
+
+    return Response(resp.content, resp.status_code, response_headers)

--- a/mise.development.toml
+++ b/mise.development.toml
@@ -11,6 +11,7 @@ SOPS_AGE_KEY_FILE = "{{vars.secret_file}}"
 _.file = "{{vars.credentials_file}}"
 
 FLASK_ENV = "development"
-MAVIS_ROOT_URL = "http://localhost:4000/"
+MAVIS_BACKEND_URL = "http://localhost:4000"
+MAVIS_ROOT_URL = "http://localhost:4001/"
 ROOT_URL = "http://localhost:{{vars.port}}/"
 SESSION_TTL_SECONDS = "600"


### PR DESCRIPTION
When running the app locally, the Reporting app lives on `localhost:4001` and Mavis continues to live on `localhost:4000`.

This is different from production, and means we can't easily tests features around things like cookie or sessionStorage sharing.

This adds a new `dev_proxy` module that transparently rewrites requests from `localhost:4001` to `localhost:4000`, making the entire journey look like it's running on `4001`.