### PR TITLE
Display counts in navigation items

### DIFF
--- a/mavis/reporting/assets/scss/_count.scss
+++ b/mavis/reporting/assets/scss/_count.scss
@@ -1,0 +1,22 @@
+@use "sass:color";
+@use "config" as *;
+
+.app-count {
+  background-color: color.scale(
+    color.scale($nhsuk-link-colour, $lightness: -50%),
+    $alpha: -60%
+  );
+  border-radius: nhsuk-spacing(3);
+  color: nhsuk-colour("white");
+  display: inline-block;
+  min-width: nhsuk-spacing(5);
+  padding-left: nhsuk-spacing(2);
+  padding-right: nhsuk-spacing(2);
+  text-align: center;
+
+  @include nhsuk-font(16);
+
+  :focus & {
+    background-color: color.scale($nhsuk-focus-text-colour, $alpha: -40%);
+  }
+}

--- a/mavis/reporting/assets/scss/_header.scss
+++ b/mavis/reporting/assets/scss/_header.scss
@@ -1,0 +1,12 @@
+@use "config" as *;
+
+.app-header__navigation-item--with-count {
+  .app-count {
+    margin-left: nhsuk-spacing(1);
+    min-width: nhsuk-spacing(4);
+    padding-bottom: 3px;
+    padding-top: 5px;
+
+    @include nhsuk-font(14, $line-height: 1);
+  }
+}

--- a/mavis/reporting/assets/scss/app.scss
+++ b/mavis/reporting/assets/scss/app.scss
@@ -7,6 +7,8 @@
 @use "data_table";
 @use "button";
 @use "environment";
+@use "count";
+@use "header";
 
 .js-enabled .js-hide {
   display: none;

--- a/mavis/reporting/templates/layouts/base.jinja
+++ b/mavis/reporting/templates/layouts/base.jinja
@@ -28,48 +28,7 @@
     "href": mavis_url("/dashboard")
   },
   "navigation": {
-    "items": [
-      {
-        "href": url_for('main.dashboard'),
-        "text": "Programmes",
-        "active": True,
-      },
-      {
-        "href": mavis_url("/sessions"),
-        "text": "Sessions",
-        "active": False,
-      },
-      {
-        "href": mavis_url("/patients"),
-        "text": "Children",
-        "active": False,
-      },
-      {
-        "href": mavis_url("/consent-forms"),
-        "text": "Unmatched responses",
-        "active": False,
-      },
-      {
-        "href": mavis_url("/school_moves"),
-        "text": "School moves",
-        "active": False,
-      },
-      {
-        "href": mavis_url("/vaccines"),
-        "text": "Vaccines",
-        "active": False,
-      },
-      {
-        "href": mavis_url("/imports"),
-        "text": "Imports",
-        "active": False,
-      },
-      {
-        "href": mavis_url("/team"),
-        "text": "Your team",
-        "active": False,
-      }
-    ]
+    "items": navigation_items
   },
   "account": session.user_nav if session.user_nav else None
 }) }}

--- a/mavis/reporting/views.py
+++ b/mavis/reporting/views.py
@@ -1,4 +1,6 @@
+import json
 import logging
+from urllib.parse import unquote
 
 from flask import (
     Blueprint,
@@ -12,6 +14,7 @@ from flask import (
     url_for,
 )
 from healthcheck import HealthCheck
+from markupsafe import Markup
 
 from mavis.reporting.api_client.client import MavisApiClient
 from mavis.reporting.forms.data_type_form import DataTypeForm
@@ -23,6 +26,7 @@ from mavis.reporting.helpers.date_helper import (
     get_last_updated_time,
 )
 from mavis.reporting.helpers.environment_helper import Environment
+from mavis.reporting.helpers.mavis_helper import mavis_url
 from mavis.reporting.helpers.secondary_nav_helper import generate_secondary_nav_items
 from mavis.reporting.models.organisation import Organisation
 
@@ -36,13 +40,79 @@ def stub_mavis_data():
     g.api_client = MavisApiClient(app=current_app, session=session)
 
 
+def _parse_navigation_counts_cookie(request):
+    nav_counts = {}
+    if cookie_value := request.cookies.get("mavis_navigation_counts"):
+        try:
+            decoded_value = unquote(cookie_value)
+            nav_counts = json.loads(decoded_value)
+            current_app.logger.info(f"Navigation counts from cookie: {nav_counts}")
+        except (json.JSONDecodeError, ValueError):
+            current_app.logger.warning(
+                f"Failed to parse navigation counts cookie: {cookie_value}"
+            )
+    else:
+        current_app.logger.info("No mavis_navigation_counts cookie found")
+    return nav_counts
+
+
+def _build_nav_item(href, text, nav_counts, active=False, count_key=None):
+    item = {"href": href, "active": active}
+
+    if count_key and (count := nav_counts.get(count_key)) is not None:
+        badge = (
+            '<span class="app-count">'
+            '<span class="nhsuk-u-visually-hidden"> (</span>'
+            f"{count}"
+            '<span class="nhsuk-u-visually-hidden">)</span>'
+            "</span>"
+        )
+        item["html"] = Markup(f"{text}{badge}")
+        item["classes"] = "app-header__navigation-item--with-count"
+    else:
+        item["text"] = text
+
+    return item
+
+
 @main.context_processor
 def inject_mavis_data():
     """Inject common data into the template context."""
     env = Environment(current_app.config["ENVIRONMENT"])
+    nav_counts = _parse_navigation_counts_cookie(request)
+
+    navigation_items = [
+        _build_nav_item(
+            url_for("main.dashboard"), "Programmes", nav_counts, active=True
+        ),
+        _build_nav_item(mavis_url(current_app, "/sessions"), "Sessions", nav_counts),
+        _build_nav_item(mavis_url(current_app, "/patients"), "Children", nav_counts),
+        _build_nav_item(
+            mavis_url(current_app, "/consent-forms"),
+            "Unmatched responses",
+            nav_counts,
+            count_key="unmatched_consent_responses",
+        ),
+        _build_nav_item(
+            mavis_url(current_app, "/school-moves"),
+            "School moves",
+            nav_counts,
+            count_key="school_moves",
+        ),
+        _build_nav_item(mavis_url(current_app, "/vaccines"), "Vaccines", nav_counts),
+        _build_nav_item(
+            mavis_url(current_app, "/imports"),
+            "Imports",
+            nav_counts,
+            count_key="imports",
+        ),
+        _build_nav_item(mavis_url(current_app, "/team"), "Your team", nav_counts),
+    ]
+
     return {
         "app_title": "Manage vaccinations in schools",
         "app_environment": env,
+        "navigation_items": navigation_items,
     }
 
 


### PR DESCRIPTION
Mavis now writes a `mavis_navigation_counts` cookie with counts for the navigation items every time the user navigates.

This parses the cookie and updates the header items to contain the dynamic counts. If the cookie isn't present, it gracefully degrades by not showing any counts.

<img width="1208" height="825" alt="498252138-1d2f578f-d3c4-483b-b60e-fa2cf2fa133c" src="https://github.com/user-attachments/assets/d6273168-bdb4-4ec4-8df7-99cf54c7aaff" />
