### PR TITLE
Add local authorities dashboard

### DIFF
--- a/mavis/reporting/api_client/client.py
+++ b/mavis/reporting/api_client/client.py
@@ -111,6 +111,36 @@ class MavisApiClient:
 
         return data
 
+    def get_local_authorities_data(self, filters=None):
+        params = {"group": "local_authority"}
+
+        if filters:
+            filter_keys = [
+                "programme",
+                "gender",
+                "year_group",
+                "academic_year",
+                "team_workgroup",
+            ]
+
+            for key in filter_keys:
+                if key in filters:
+                    params[key] = filters[key]
+
+        response = mavis_helper.api_call(
+            self.app, self.session, "/api/reporting/totals", params=params
+        )
+        data = parse_json_response(response, "Local authorities data")
+
+        if not isinstance(data, list):
+            raise MavisApiError(
+                "Local authorities data response must be a list",
+                status_code=response.status_code,
+                response_body=str(data),
+            )
+
+        return data
+
     def download_totals_csv(self, programme, team_workgroup, variables=None):
         params = {"programme": programme, "team_workgroup": team_workgroup}
 

--- a/mavis/reporting/helpers/secondary_nav_helper.py
+++ b/mavis/reporting/helpers/secondary_nav_helper.py
@@ -19,6 +19,11 @@ def generate_secondary_nav_items(team_workgroup: str, current_page: str):
             "current": current_page == "schools",
         },
         {
+            "text": "Local authorities",
+            "href": url_for("main.local_authorities", workgroup=team_workgroup),
+            "current": current_page == "local_authorities",
+        },
+        {
             "text": "Download data",
             "href": url_for("main.start_download", workgroup=team_workgroup),
             "current": current_page == "download",

--- a/mavis/reporting/templates/local_authorities.jinja
+++ b/mavis/reporting/templates/local_authorities.jinja
@@ -1,0 +1,54 @@
+{% from "components/filters.jinja" import filters %}
+{% from "tables/macro.jinja" import table %}
+
+{% extends 'layouts/dashboard.jinja' %}
+
+{% block pageTitle %}Local authorities report | {{ app_title }}{% endblock %}
+
+{% block dashboard_content %}
+
+<div class="nhsuk-grid-row">
+  <div class="app-grid-column-filters">
+    {{ filters({
+      "programmes": programmes,
+      "year_groups": year_groups,
+      "genders": genders,
+      "current_filters": current_filters or {},
+      "form_action": url_for('main.local_authorities', workgroup=team.workgroup)
+    }) }}
+  </div>
+
+  <div id="dashboard" class="app-grid-column-content">
+    {% set rows = [] %}
+    {% for la in local_authorities_data %}
+      {% set _ = rows.append([
+        { "text": la.local_authority_official_name },
+        { "text": la.cohort | thousands, "format": "numeric" },
+        { "text": la.consent_no_response | thousands, "format": "numeric" },
+        { "text": la.consent_given | thousands, "format": "numeric" },
+        { "text": la.vaccinated | thousands, "format": "numeric" },
+      ]) %}
+    {% endfor %}
+
+    {{ table({
+      "heading": "Local authorities",
+      "tableClasses": "nhsuk-table--data",
+      "panel": true,
+      "head": [
+        { "text": "Local authority" },
+        { "text": "Cohort", "format": "numeric" },
+        { "text": "No response", "format": "numeric" },
+        { "text": "Consent given", "format": "numeric" },
+        { "text": "Vaccinated", "format": "numeric" },
+      ],
+      "rows": rows
+    }) }}
+
+    <p class="nhsuk-body-m nhsuk-u-margin-bottom-6">
+      This data was last updated on <strong>{{ last_updated_time }}</strong>.
+    </p>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/mavis/reporting/views.py
+++ b/mavis/reporting/views.py
@@ -230,6 +230,40 @@ def schools(workgroup):
     )
 
 
+@main.route("/team/<workgroup>/local-authorities")
+@auth_helper.login_required
+def local_authorities(workgroup):
+    team = Team.get_from_session(session)
+    if team.workgroup != workgroup:
+        return redirect(url_for("main.local_authorities", workgroup=team.workgroup))
+
+    breadcrumb_items = generate_breadcrumb_items()
+
+    selected_item_text = "Local authorities"
+    secondary_navigation_items = generate_secondary_nav_items(
+        team.workgroup,
+        current_page="local_authorities",
+    )
+
+    filters, year_groups = build_report_filters(team, g.api_client)
+    local_authorities_data = g.api_client.get_local_authorities_data(filters)
+
+    return render_template(
+        "local_authorities.jinja",
+        team=team,
+        programmes=g.api_client.get_programmes(),
+        year_groups=year_groups,
+        genders=g.api_client.get_genders(),
+        academic_year=get_current_academic_year_range(),
+        local_authorities_data=local_authorities_data,
+        current_filters=filters,
+        breadcrumb_items=breadcrumb_items,
+        selected_item_text=selected_item_text,
+        secondary_navigation_items=secondary_navigation_items,
+        last_updated_time=get_last_updated_time(),
+    )
+
+
 @main.errorhandler(404)
 def page_not_found(_error):
     return render_template("errors/404.html"), 404

--- a/tests/views/test_local_authorities.py
+++ b/tests/views/test_local_authorities.py
@@ -1,0 +1,76 @@
+# ruff: noqa: PLR2004
+
+from http import HTTPStatus
+
+from bs4 import BeautifulSoup
+
+from mavis.reporting.helpers import auth_helper
+from tests.conftest import MockResponse
+from tests.helpers import mock_user_info
+
+MOCK_LOCAL_AUTHORITIES_DATA = [
+    {
+        "local_authority_official_name": "Test County Council",
+        "cohort": 100,
+        "consent_no_response": 10,
+        "consent_given": 80,
+        "vaccinated": 75,
+    },
+    {
+        "local_authority_official_name": "Test Borough Council",
+        "cohort": 200,
+        "consent_no_response": 20,
+        "consent_given": 160,
+        "vaccinated": 150,
+    },
+]
+
+
+def _get_local_authorities_page(app, client, mock_mavis_get_request):
+    app.config["ROOT_URL"] = "http://mavis.test/reports/"
+    app.config["WTF_CSRF_ENABLED"] = False
+
+    with app.app_context():
+        with client.session_transaction() as session:
+            auth_helper.log_user_in(mock_user_info(), session)
+
+        mock_mavis_get_request(MockResponse(json_obj=MOCK_LOCAL_AUTHORITIES_DATA))
+        response = client.get("/reports/team/r1l/local-authorities")
+
+    return response
+
+
+def test_local_authorities_view_has_expected_table_headers(
+    app, client, mock_mavis_get_request
+):
+    response = _get_local_authorities_page(app, client, mock_mavis_get_request)
+    assert response.status_code == HTTPStatus.OK
+
+    soup = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
+
+    headers = [th.get_text(strip=True) for th in soup.find_all("th")]
+
+    assert "Local authority" in headers
+    assert "Cohort" in headers
+    assert "No response" in headers
+    assert "Consent given" in headers
+    assert "Vaccinated" in headers
+
+
+def test_local_authorities_view_renders_data_in_table(
+    app, client, mock_mavis_get_request
+):
+    response = _get_local_authorities_page(app, client, mock_mavis_get_request)
+    soup = BeautifulSoup(response.data.decode("utf-8"), "html.parser")
+
+    table_body = soup.find("tbody")
+    assert table_body is not None
+    rows = table_body.find_all("tr")
+
+    assert len(rows) == 2
+
+    first_row_cells = [td.get_text(strip=True) for td in rows[0].find_all("td")]
+    assert "Test County Council" in first_row_cells
+
+    second_row_cells = [td.get_text(strip=True) for td in rows[1].find_all("td")]
+    assert "Test Borough Council" in second_row_cells


### PR DESCRIPTION
Adds a new "Local authorities" tab to the reporting dashboard, mirroring the schools dashboard but grouping data by local authority using the existing Mavis API endpoint.