### PR TITLE
Replace "school year" with "academic year"

### DIFF
--- a/mavis/reporting/templates/layouts/dashboard.jinja
+++ b/mavis/reporting/templates/layouts/dashboard.jinja
@@ -8,7 +8,7 @@
     "text": "Reports",
     "level": 1,
     "size": "l",
-    "summary": "For the " ~ academic_year ~ " school year so far"
+    "summary": "For the " ~ academic_year ~ " academic year so far"
   }) }}
 {% endblock %}
 


### PR DESCRIPTION
For clarity for SAIS teams and consistency with the rest of Mavis.