### PR TITLE
Fix call to `response.ok`

### DIFF
--- a/mavis/reporting/helpers/mavis_helper.py
+++ b/mavis/reporting/helpers/mavis_helper.py
@@ -74,7 +74,7 @@ def validate_http_response(response, session=None, context="API response"):
             session.clear()
         raise Unauthorized()
 
-    if not response.ok:
+    if not response.is_success:
         raise MavisApiError(
             f"{context}: {response.status_code}",
             status_code=response.status_code,

--- a/tests/auth/test_auth.py
+++ b/tests/auth/test_auth.py
@@ -98,7 +98,7 @@ def test_when_api_returns_401_with_stale_session_it_redirects_to_mavis_start(
 
         mock_response = MagicMock()
         mock_response.status_code = HTTPStatus.UNAUTHORIZED
-        mock_response.ok = False
+        mock_response.is_success = False
 
         with patch(
             "mavis.reporting.helpers.mavis_helper.get_request",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,7 @@ class MockResponse:
             self.content = self.text.encode()
         else:
             self.content = b""
-        self.ok = (
+        self.is_success = (
             self.status_code >= HTTPStatus.OK
             and self.status_code < HTTPStatus.MULTIPLE_CHOICES
             if self.status_code


### PR DESCRIPTION
This used to be a property when using `requests` but has been replaced in `httpx` with `is_success`.

This fixes a regression that was introduced in 284e6eec8a3863bee0ca91dabedd1e0deb10ecc7.

[Jira Issue - MAV-5585](https://nhsd-jira.digital.nhs.uk/browse/MAV-5585)