### PR TITLE
Split vaccination counts by school and community

### DIFF
--- a/mavis/reporting/templates/vaccinations.jinja
+++ b/mavis/reporting/templates/vaccinations.jinja
@@ -52,12 +52,14 @@
     {% for row in data.monthly_vaccinations_given %}
       {% set _ = rows.append([
         { "text": row.month ~ " " ~ row.year },
-        { "text": row.count | thousands, "format": "numeric" }
+        { "text": row.school_count | thousands, "format": "numeric" },
+        { "text": row.community_count | thousands, "format": "numeric" }
       ]) %}
     {% endfor %}
     {% set _ = rows.append([
       { "text": "Total" },
-      { "text": data.vaccinations_given | thousands, "format": "numeric" }
+      { "text": data.vaccinations_given.school_count | thousands, "format": "numeric" },
+      { "text": data.vaccinations_given.community_count | thousands, "format": "numeric" }
     ]) %}
 
     {{ table({
@@ -66,7 +68,8 @@
       "panel": true,
       "head": [
         { "text": "Month", "format": "date"},
-        { "text": "Number of vaccinations", "format": "numeric" }
+        { "text": "School", "format": "numeric" },
+        { "text": "Community", "format": "numeric" }
       ],
       "rows": rows
     }) }}

--- a/tests/auth/test_auth.py
+++ b/tests/auth/test_auth.py
@@ -35,7 +35,7 @@ def test_when_session_has_a_user_id_and_is_not_expired_it_does_not_redirect(
             "cohort": 546,
             "vaccinated": 456,
             "not_vaccinated": 90,
-            "vaccinations_given": 402,
+            "vaccinations_given": {"school_count": 350, "community_count": 52},
             "consent_given": 400,
             "no_consent": 146,
             "consent_no_response": 100,
@@ -45,17 +45,20 @@ def test_when_session_has_a_user_id_and_is_not_expired_it_does_not_redirect(
                 {
                     "month": "September",
                     "year": 2025,
-                    "count": 121,
+                    "school_count": 121,
+                    "community_count": 0,
                 },
                 {
                     "month": "October",
                     "year": 2025,
-                    "count": 145,
+                    "school_count": 145,
+                    "community_count": 0,
                 },
                 {
                     "month": "November",
                     "year": 2025,
-                    "count": 136,
+                    "school_count": 136,
+                    "community_count": 0,
                 },
             ],
         }


### PR DESCRIPTION
The reporting API now returns `school_count` and `community_count` instead of a single count, so we can display this on the vaccinations dashboard.

<img width="1179" height="737" alt="571145538-637921e3-4654-490a-86c8-f23ced1d0e44" src="https://github.com/user-attachments/assets/c8d5b035-9898-4bc6-989e-763a1b8e4fde" />

[Jira Issue - MAV-5741](https://nhsd-jira.digital.nhs.uk/browse/MAV-5741)