### PR TITLE
Ensure only `next` can be merged in to `main`

### DIFF
--- a/.github/workflows/prevent-merging-in-to-main.yml
+++ b/.github/workflows/prevent-merging-in-to-main.yml
@@ -1,0 +1,16 @@
+name: Prevent merging in to main
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ensure-source-is-next:
+    name: Ensure source branch is next
+    runs-on: ubuntu-latest
+    if: github.head_ref == 'next'
+    steps:
+      - run: echo "Pull request can be merged in to main"


### PR DESCRIPTION
This adds a workflow which checks when raising a PR against `main` that the source branch is `next`. This should prevent accidental merges in to `main`, which can happen when Dependabot raises security PRs (as in that case it always raises against `main` and not `next`).

Once this workflow has been added, we'll need to add a branch protection rule that checks that the workflow runs.

In the case of an emergency release, where we do need to merge a branch other than `next` in to `main`, we can temporarily disable the branch protection rule.