### PR TITLE
Remove MAVIS_ROOT_URL from mise config

### DIFF
--- a/mise.production.toml
+++ b/mise.production.toml
@@ -11,5 +11,5 @@ SOPS_AGE_KEY_FILE = "{{vars.secret_file}}"
 _.file = "{{vars.credentials_file}}"
 
 FLASK_ENV = "production"
-MAVIS_ROOT_URL = "http://web:4000/"
+# MAVIS_ROOT_URL = "configured by terraform/app/variables.tf in the mavis repo"
 # ROOT_URL = "configured by terraform/app/variables.tf in the mavis repo"

--- a/mise.staging.toml
+++ b/mise.staging.toml
@@ -12,5 +12,5 @@ _.file = "{{vars.credentials_file}}"
 
 FLASK_ENV = "staging"
 # SENTRY_ENVIRONMENT = "configured by terraform/app/variables.tf in the mavis repo"
-MAVIS_ROOT_URL = "http://web:4000/"
+# MAVIS_ROOT_URL = "configured by terraform/app/variables.tf in the mavis repo"
 # ROOT_URL = "configured by terraform/app/variables.tf in the mavis repo"


### PR DESCRIPTION
- This allows the variable to be used directly from environment variables
- Necessary for populating the variable via environment config
This requires that the infrastructure [PR](https://github.com/NHSDigital/manage-vaccinations-in-schools-infrastructure/pull/29) is deployed first so that the value is available in the task

[Jira Issue - MAV-6047](https://nhsd-jira.digital.nhs.uk/browse/MAV-6047)