### PR TITLE
Pin all GitHub Actions to commit SHAs for security

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -32,7 +32,7 @@ jobs:
         steps.check-prod-image.outputs.build-needed }}
     steps:
       - name: Configure AWS Dev Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: arn:aws:iam::393416225559:role/GithubDeployECSService
           aws-region: eu-west-2
@@ -48,7 +48,7 @@ jobs:
           fi
       - name: Configure AWS Production credentials
         if: env.PUSH_IMAGE_TO_PRODUCTION == 'true'
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: arn:aws:iam::820242920762:role/GithubDeployECSService
           aws-region: eu-west-2
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.git-sha || github.sha }}
       - name: Make sure public dir is present
@@ -82,7 +82,7 @@ jobs:
       - name: Save Docker image
         run: docker save -o image.tar mavis-reporting:latest
       - name: Upload Docker image
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: image
           path: image.tar
@@ -113,17 +113,17 @@ jobs:
         aws-role: ${{ fromJSON(needs.define-matrix.outputs.aws-roles) }}
     steps:
       - name: Download Docker image
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: image
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: ${{ matrix.aws-role }}
           aws-region: eu-west-2
       - name: Login to ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
       - name: Load Docker image
         run: docker load -i image.tar
       # yamllint disable rule:line-length

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:
           cache: true
       - run: mise actionlint
@@ -20,10 +20,10 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # Full history is needed to scan all commits
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:
           cache: true
       - run: mise gitleaks
@@ -31,8 +31,8 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:
           cache: true
       - env:
@@ -42,8 +42,8 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:
           cache: true
       - run: mise lint
@@ -51,8 +51,8 @@ jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:
           cache: true
       - run: mise yamllint
@@ -65,15 +65,15 @@ jobs:
       badge_url: ${{ steps.upload-coverage-badge-artifact-step.outputs.artifact-url }}
       html_report_url: ${{ steps.upload-html-report-artifact-step.outputs.artifact-url }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           cache: true
       - env:
           SECRET_KEY: "${{ secrets.SECRET_KEY_FOR_TESTS }}"
           COVERAGE_THRESHOLD: 80
         run: mise test:coverage
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         id: upload-html-report-artifact-step
         if: always()
         with:
@@ -81,7 +81,7 @@ jobs:
           path: htmlcov
           retention-days: 10
           compression-level: 0
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         id: upload-coverage-badge-artifact-step
         if: always()
         with:

--- a/.github/workflows/deploy-application.yml
+++ b/.github/workflows/deploy-application.yml
@@ -91,11 +91,11 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.determine-git-sha.outputs.git-sha }}
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: ${{ env.aws_role }}
           aws-region: eu-west-2
@@ -110,7 +110,7 @@ jobs:
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
       - name: Populate reporting task definition
         id: create-task-definition
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        uses: aws-actions/amazon-ecs-render-task-definition@77954e213ba1f9f9cb016b86a1d4f6fcdea0d57e # v1.8.4
         with:
           task-definition-family: mavis-reporting-task-definition-${{ inputs.environment }}-template
           container-name: application
@@ -121,7 +121,7 @@ jobs:
           mv ${{ steps.create-task-definition.outputs.task-definition }}
           ${{ runner.temp }}/reporting-task-definition.json
       - name: Upload artifact for reporting task definition
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.environment }}-reporting-task-definition
           path: ${{ runner.temp }}/reporting-task-definition.json
@@ -135,12 +135,12 @@ jobs:
       id-token: write
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: ${{ env.aws_role }}
           aws-region: eu-west-2
       - name: Download reporting task definition artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ runner.temp }}
           name: ${{ inputs.environment }}-reporting-task-definition
@@ -150,7 +150,7 @@ jobs:
           family_name="mavis-reporting-task-definition-${{ inputs.environment }}"
           jq --arg f "$family_name" '.family = $f' "$file_path" > tmpfile && mv tmpfile "$file_path"
       - name: Deploy reporting service
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        uses: aws-actions/amazon-ecs-deploy-task-definition@fc8fc60f3a60ffd500fcb13b209c59d221ac8c8c # v2.6.1
         with:
           task-definition: ${{ runner.temp }}/reporting-task-definition.json
           cluster: ${{ env.cluster_name }}

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -6,7 +6,9 @@ ignore-from-file: .gitignore
 rules:
   document-start: disable
   line-length:
-    max: 100
     ignore: config/credentials/*
+    # Ideally, this value would be smaller, but it makes dealing with long lines
+    #  including commit SHAs, etc. very difficult.
+    max: 120
   truthy:
     ignore: .github/workflows/*


### PR DESCRIPTION
This reduces the risk of supply chain attacks where the tag points to a different commit implicitly without us being aware.

[Jira Issue - MAV-5897](https://nhsd-jira.digital.nhs.uk/browse/MAV-5897)