### PR TITLE
Add consent refusal reason and route breakdowns

### DIFF
--- a/mavis/reporting/api_client/client.py
+++ b/mavis/reporting/api_client/client.py
@@ -35,6 +35,21 @@ class MavisApiClient:
             data["consent_no_response_percentage"] = 0
             data["consent_refused_percentage"] = 0
             data["consent_conflicts_percentage"] = 0
+
+        refused = data.get("consent_refused", 0)
+        refusal_reasons = data.get("consent_refusal_reasons", {})
+        data["consent_refusal_reasons_percentages"] = {
+            k: v / refused if refused > 0 else 0
+            for k, v in refusal_reasons.items()
+        }
+
+        route_counts = data.get("consent_routes", {})
+        route_total = sum(route_counts.values())
+        data["consent_routes_percentages"] = {
+            k: v / route_total if route_total > 0 else 0
+            for k, v in route_counts.items()
+        }
+
         return data
 
     def get_vaccination_data(self, filters=None):

--- a/mavis/reporting/api_client/client.py
+++ b/mavis/reporting/api_client/client.py
@@ -39,8 +39,7 @@ class MavisApiClient:
         refused = data.get("consent_refused", 0)
         refusal_reasons = data.get("consent_refusal_reasons", {})
         data["consent_refusal_reasons_percentages"] = {
-            k: v / refused if refused > 0 else 0
-            for k, v in refusal_reasons.items()
+            k: v / refused if refused > 0 else 0 for k, v in refusal_reasons.items()
         }
 
         route_counts = data.get("consent_routes", {})
@@ -207,4 +206,26 @@ class MavisApiClient:
             {"value": "male", "text": "Male"},
             {"value": "not known", "text": "Not known"},
             {"value": "not specified", "text": "Not specified"},
+        ]
+
+    def get_consent_refusal_reasons(self) -> list[dict]:
+        return [
+            {"value": "contains_gelatine", "text": "Vaccine contains gelatine"},
+            {"value": "already_vaccinated", "text": "Already vaccinated"},
+            {
+                "value": "will_be_vaccinated_elsewhere",
+                "text": "Vaccine will be given elsewhere",
+            },
+            {"value": "medical_reasons", "text": "Medical reasons"},
+            {"value": "personal_choice", "text": "Personal choice"},
+            {"value": "other", "text": "Other"},
+        ]
+
+    def get_consent_routes(self) -> list[dict]:
+        return [
+            {"value": "website", "text": "Website"},
+            {"value": "phone", "text": "Phone"},
+            {"value": "paper", "text": "Paper"},
+            {"value": "in_person", "text": "In person"},
+            {"value": "self_consent", "text": "Self-consent"},
         ]

--- a/mavis/reporting/api_client/client.py
+++ b/mavis/reporting/api_client/client.py
@@ -36,10 +36,11 @@ class MavisApiClient:
             data["consent_refused_percentage"] = 0
             data["consent_conflicts_percentage"] = 0
 
-        refused = data.get("consent_refused", 0)
-        refusal_reasons = data.get("consent_refusal_reasons", {})
+        refusal_reason_counts = data.get("consent_refusal_reasons", {})
+        refusal_reason_total = sum(refusal_reason_counts.values())
         data["consent_refusal_reasons_percentages"] = {
-            k: v / refused if refused > 0 else 0 for k, v in refusal_reasons.items()
+            k: v / refusal_reason_total if refusal_reason_total > 0 else 0
+            for k, v in refusal_reason_counts.items()
         }
 
         route_counts = data.get("consent_routes", {})

--- a/mavis/reporting/api_client/client.py
+++ b/mavis/reporting/api_client/client.py
@@ -217,6 +217,10 @@ class MavisApiClient:
                 "value": "will_be_vaccinated_elsewhere",
                 "text": "Vaccine will be given elsewhere",
             },
+            {
+                "value": "do_not_want_vaccination_at_school",
+                "text": "Do not want vaccination at school",
+            },
             {"value": "medical_reasons", "text": "Medical reasons"},
             {"value": "personal_choice", "text": "Personal choice"},
             {"value": "other", "text": "Other"},

--- a/mavis/reporting/templates/consents.jinja
+++ b/mavis/reporting/templates/consents.jinja
@@ -77,6 +77,61 @@
       }) }}
     </div>
 
+    {% set refusal_reasons = [
+      ["contains_gelatine", "Vaccine contains gelatine"],
+      ["already_vaccinated", "Already vaccinated"],
+      ["will_be_vaccinated_elsewhere", "Vaccine will be given elsewhere"],
+      ["medical_reasons", "Medical reasons"],
+      ["personal_choice", "Personal choice"],
+      ["other", "Other"],
+    ] %}
+
+    {% set refusal_rows = [] %}
+    {% for key, label in refusal_reasons %}
+      {% set _ = refusal_rows.append([
+        { "text": label },
+        { "text": data["consent_refusal_reasons_percentages"][key] | percentage, "format": "numeric" }
+      ]) %}
+    {% endfor %}
+
+    {{ table({
+      "heading": "Reasons consent refused",
+      "tableClasses": "nhsuk-table--data",
+      "panel": true,
+      "head": [
+        { "text": "Reason" },
+        { "text": "Percentage", "format": "numeric" }
+      ],
+      "rows": refusal_rows
+    }) }}
+
+    {% set consent_routes = [
+      ["website", "Website"],
+      ["phone", "Phone"],
+      ["paper", "Paper"],
+      ["in_person", "In person"],
+      ["self_consent", "Self-consent"],
+    ] %}
+
+    {% set route_rows = [] %}
+    {% for key, label in consent_routes %}
+      {% set _ = route_rows.append([
+        { "text": label },
+        { "text": data["consent_routes_percentages"][key] | percentage, "format": "numeric" }
+      ]) %}
+    {% endfor %}
+
+    {{ table({
+      "heading": "Consent responses by method",
+      "tableClasses": "nhsuk-table--data",
+      "panel": true,
+      "head": [
+        { "text": "Method" },
+        { "text": "Percentage", "format": "numeric" }
+      ],
+      "rows": route_rows
+    }) }}
+
     <p class="nhsuk-body-m nhsuk-u-margin-bottom-6">
       This data was last updated on <strong>{{ last_updated_time }}</strong>.
     </p>

--- a/mavis/reporting/templates/consents.jinja
+++ b/mavis/reporting/templates/consents.jinja
@@ -77,20 +77,11 @@
       }) }}
     </div>
 
-    {% set refusal_reasons = [
-      ["contains_gelatine", "Vaccine contains gelatine"],
-      ["already_vaccinated", "Already vaccinated"],
-      ["will_be_vaccinated_elsewhere", "Vaccine will be given elsewhere"],
-      ["medical_reasons", "Medical reasons"],
-      ["personal_choice", "Personal choice"],
-      ["other", "Other"],
-    ] %}
-
     {% set refusal_rows = [] %}
-    {% for key, label in refusal_reasons %}
+    {% for reason in refusal_reasons %}
       {% set _ = refusal_rows.append([
-        { "text": label },
-        { "text": data["consent_refusal_reasons_percentages"][key] | percentage, "format": "numeric" }
+        { "text": reason.text },
+        { "text": data["consent_refusal_reasons_percentages"][reason.value] | percentage, "format": "numeric" }
       ]) %}
     {% endfor %}
 
@@ -105,19 +96,11 @@
       "rows": refusal_rows
     }) }}
 
-    {% set consent_routes = [
-      ["website", "Website"],
-      ["phone", "Phone"],
-      ["paper", "Paper"],
-      ["in_person", "In person"],
-      ["self_consent", "Self-consent"],
-    ] %}
-
     {% set route_rows = [] %}
-    {% for key, label in consent_routes %}
+    {% for route in consent_routes %}
       {% set _ = route_rows.append([
-        { "text": label },
-        { "text": data["consent_routes_percentages"][key] | percentage, "format": "numeric" }
+        { "text": route.text },
+        { "text": data["consent_routes_percentages"][route.value] | percentage, "format": "numeric" }
       ]) %}
     {% endfor %}
 

--- a/mavis/reporting/views.py
+++ b/mavis/reporting/views.py
@@ -178,6 +178,8 @@ def consent(workgroup):
         year_groups=year_groups,
         genders=g.api_client.get_genders(),
         academic_year=get_current_academic_year_range(),
+        refusal_reasons=g.api_client.get_consent_refusal_reasons(),
+        consent_routes=g.api_client.get_consent_routes(),
         data=data,
         current_filters=filters,
         selected_item_text=selected_item_text,

--- a/tests/api_client/test_client.py
+++ b/tests/api_client/test_client.py
@@ -38,6 +38,21 @@ def test_valid_vaccination_data(api_client, mock_mavis_get_request):
                 "consent_no_response": 30,
                 "consent_refused": 8,
                 "consent_conflicts": 2,
+                "consent_refusal_reasons": {
+                    "contains_gelatine": 1,
+                    "already_vaccinated": 2,
+                    "will_be_vaccinated_elsewhere": 1,
+                    "medical_reasons": 1,
+                    "personal_choice": 2,
+                    "other": 1,
+                },
+                "consent_routes": {
+                    "website": 40,
+                    "phone": 10,
+                    "paper": 5,
+                    "in_person": 3,
+                    "self_consent": 2,
+                },
             }
         )
     )
@@ -48,6 +63,8 @@ def test_valid_vaccination_data(api_client, mock_mavis_get_request):
     assert "vaccinated_percentage" in result
     assert "consent_refused_percentage" in result
     assert "consent_conflicts_percentage" in result
+    assert "consent_refusal_reasons_percentages" in result
+    assert "consent_routes_percentages" in result
 
 
 class TestGetYearGroupsForProgramme:

--- a/tests/auth/test_auth.py
+++ b/tests/auth/test_auth.py
@@ -41,6 +41,21 @@ def test_when_session_has_a_user_id_and_is_not_expired_it_does_not_redirect(
             "consent_no_response": 100,
             "consent_refused": 30,
             "consent_conflicts": 16,
+            "consent_refusal_reasons": {
+                "contains_gelatine": 1,
+                "already_vaccinated": 8,
+                "will_be_vaccinated_elsewhere": 5,
+                "medical_reasons": 3,
+                "personal_choice": 12,
+                "other": 1,
+            },
+            "consent_routes": {
+                "website": 320,
+                "phone": 45,
+                "paper": 22,
+                "in_person": 10,
+                "self_consent": 3,
+            },
             "monthly_vaccinations_given": [
                 {
                     "month": "September",


### PR DESCRIPTION
The consent dashboard now shows two new tables: reasons consent was refused (as percentages of all refusals) and consent responses by method (as percentages of all responses).

## Screenshot

<img width="2880" height="4382" alt="571287867-0576b492-8a1d-4557-bc76-639ab9dfd992" src="https://github.com/user-attachments/assets/e5bd3114-fd71-4e64-8d08-18a0595b1966" />
